### PR TITLE
Hard-setting gatk to version 4.1.0.0 because of errors

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -29,13 +29,13 @@
   withName:MarkDuplicates {
     // Actually the -Xmx value should be kept lower,
     // and is set through the markdup_java_options; cf https://github.com/SciLifeLab/Sarek/blob/master/conf/resources.config#L31
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:CreateRecalibrationTable {
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:RecalibrateBam {
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:Alfred {
     container = "sinisa88/alfred:v0.1.17"
@@ -53,16 +53,16 @@
     container = "cmopipeline/delly:v0.8.1"
   }
   withName:CreateIntervalBeds {
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:runMutect2 {
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:indexVCF {
     container = "cmopipeline/tabix:latest"
   }
   withName:runMutect2Filter {
-    container = "broadinstitute/gatk:latest"
+    container = "broadinstitute/gatk:4.1.0.0"
   }
   withName:combineMutect2VCF {
     container = "halllab/bcftools:v1.9"


### PR DESCRIPTION
Should fix errors that crop up from the `latest` image on docker hub