### PR TITLE
Markdup per lane

### DIFF
--- a/make_bam_and_qc.nf
+++ b/make_bam_and_qc.nf
@@ -7,7 +7,7 @@
  - AlignReads - Map reads with BWA mem output SAM
  - SortBAM - Sort BAM with samtools
  - MarkDuplicates - Mark Duplicates with GATK4
- - MergeBam - Merge BAMs from differen lanes for the same sample
+ - MergeBam - Merge BAMs from different lanes for the same sample
  - CreateRecalibrationTable - Create Recalibration Table with BaseRecalibrator
  - RecalibrateBam - Recalibrate Bam with PrintReads
 */


### PR DESCRIPTION
1. move `MarkDuplicate` before `MergeBam`， to improve performance
2. change `tag` in each step to avoid duplicated information