### PR TITLE
Update container facets suite 1.5.7

### DIFF
--- a/containers/facets-suite/Dockerfile
+++ b/containers/facets-suite/Dockerfile
@@ -24,6 +24,8 @@ RUN apk add --update \
         && apk add cairo cairo-dev libxt-dev libxml2-dev font-xfree86-type1 \
     # download and install R
         && apk add R R-dev \
+    # change permissions for /tmp; still doesn't resolve R warnings
+        && chmod  777 -R /tmp \
     # download and unzip facets, facets-suite, pctGCdata
         && cd /tmp \
 	    && wget https://github.com/mskcc/facets-suite/archive/${FACETS_SUITE_VERSION}.tar.gz -O facets-suite-${FACETS_SUITE_VERSION}.tar.gz \
@@ -53,7 +55,7 @@ RUN apk add --update \
                 && sed -i "s/opt\/common\/CentOS_6-dev\/R\/R-3.2.2\//usr\//g" *.R \
             # copy execs to /usr/bin/facets-suite
                 && mkdir -p /usr/bin/facets-suite/ \
-                && cp /tmp/facets-suite-${FACETS_SUITE_VERSION}/* /usr/bin/facets-suite/ \
+                && cp -r /tmp/facets-suite-${FACETS_SUITE_VERSION}/* /usr/bin/facets-suite/ \
     # clean up
         && rm -rf /var/cache/apk/* /tmp/*
 


### PR DESCRIPTION
This updates the facets-suite Dockerfile in order to use the latest R repo with @kpjonsson et al changed, v1.5.7

https://github.com/mskcc/facets-suite/releases/tag/1.5.7

Image re-tagged, etc. 

Also, I think the original 1.5.6 was the Roslin image re-tagged? I found errors building the Docker image from scratch, as copy needed to be recursive, i.e. `cp -r /tmp/facets-suite-${FACETS_SUITE_VERSION}/*`