### PR TITLE
Wrong process name for Polysolver

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -82,7 +82,7 @@
   withName:RunMsiSensor {
     container = "vanallenlab/msisensor:0.5"
   }
-  withName:Polysolver {
+  withName:RunPolysolver {
     container = "sachet/polysolver:v4"
   }
   withName:RunConpair {


### PR DESCRIPTION
Wrong process name in `containers.config`.