### PR TITLE
revised channels FacetsAnnotationOutput/mafFileForNeoantigen 

### DIFF
--- a/make_bam_and_qc.nf
+++ b/make_bam_and_qc.nf
@@ -226,7 +226,7 @@ process RecalibrateBam {
     ])
 
   output:
-    set idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBam, recalibratedBamForStats, recalibratedBamForOutput, recalibratedBamForOutput2
+    set idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBam, recalibratedBamForOutput, recalibratedBamForOutput2
     set idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBamTSV
     val(idSample) into currentSample
     file("${idSample}.recal.bam") into currentBam

--- a/pipeline.nf
+++ b/pipeline.nf
@@ -269,7 +269,7 @@ process RecalibrateBam {
     ])
 
   output:
-    set idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBam, recalibratedBamForStats, recalibratedBamForOutput, recalibratedBamForOutput2
+    set idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBam, recalibratedBamForOutput, recalibratedBamForOutput2
     set idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bam.bai"), assay, targetFile into recalibratedBamTSV
     val(idSample) into currentSample
     file("${idSample}.recal.bam") into currentBam


### PR DESCRIPTION
Discussed here:
https://github.com/mskcc/vaporware/pull/454

This fix should remove the warning:

```
WARN: Input tuple does not match input set cardinality declared by process `RunNeoantigen` -- offending value: 
[BRCA_00067-T, BRCA_00067-N, agilent, /juno/work/taylorlab/biederstedte/sandbox/collectHsMetrics_try14July2019/work/2b/9171dbc464105abf9a5ac1b879023e/./winners.hla.txt, 
[/juno/work/taylorlab/biederstedte/sandbox/collectHsMetrics_try14July2019/work/98/8688ce843166fbe1ce1a2b9043a8f4/BRCA_00067-T_vs_BRCA_00067-N.facets.maf], 
[/juno/work/taylorlab/biederstedte/sandbox/collectHsMetrics_try14July2019/work/98/8688ce843166fbe1ce1a2b9043a8f4/BRCA_00067-T_vs_BRCA_00067-N.armlevel.tsv], 
[/juno/work/taylorlab/biederstedte/sandbox/collectHsMetrics_try14July2019/work/98/8688ce843166fbe1ce1a2b9043a8f4/BRCA_00067-T_vs_BRCA_00067-N.genelevel.tsv], 
[/juno/work/taylorlab/biederstedte/sandbox/collectHsMetrics_try14July2019/work/98/8688ce843166fbe1ce1a2b9043a8f4/BRCA_00067-T_vs_BRCA_00067-N.genelevel_TSG_ManualReview.txt]]
```
