### PR TITLE
fixed bug in RecalibrateBam, item[3][0] should be item[3]

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -348,8 +348,8 @@ if (!params.bam_pairing){
                             def idSample = item[0]
                             def sampleBam = item[1]
                             def sampleBai = item[2]
-                            def assay = item[3][0]
-                            def target = item[4][0]
+                            def assay = item[3]
+                            def target = item[4]
                             def idTumor = item[5]
                             def idNormal = item[6]
                             def bamTumor = sampleBam


### PR DESCRIPTION
As @allanbolipata mentioned, there's a bug. 

I'm not sure where this happened, but it looks like this was in `accept_BAM_inputs`....though I don't know why. Possibly a bad merge/typo. 

**Bug:** 

I went into a finished, cached pipeline run and looked at the contents of the channels using the following "trick":

```
(testChannelA, Channel) = Channel.into(2)
testChannelA.subscribe{ println it }
```

I noticed these channels were empty, which explains why Mutect2 isn't running:

```
// These will go into mutect2 and haplotypecaller
(mergedChannelSomatic, mergedChannelGermline) = aMergedChannel.concat( bMergedChannel, wMergedChannel).into(2) // { mergedChannelSomatic, mergedChannelGermline }
```

So I worked backwards and compared against `Release/0.18.0`. 

`mdBam` looked fine

```
mdBam.subscribe{ println it }

[7c/4d81cd] process > MarkDuplicates           [100%] 2 of 2, cached: 2
[BRCA_00067-T, /juno/work/taylorlab/biederstedte/sandbox/debug/work/6d/bac81f042edb886006d74c86385ca5/BRCA_00067-T.md.bam, /juno/work/taylorlab/biederstedte/sandbox/debug/work/6d/bac81f042edb886006d74c86385ca5/BRCA_00067-T.md.bai, wes, agilent]
[BRCA_00067-N, /juno/work/taylorlab/biederstedte/sandbox/debug/work/fc/802674d8323bad3e8724b5ea60dca0/BRCA_00067-N.md.bam, /juno/work/taylorlab/biederstedte/sandbox/debug/work/fc/802674d8323bad3e8724b5ea60dca0/BRCA_00067-N.md.bai, wes, agilent]
```

Here is the correct output to `bamFiles`:
```
[agilent, wes, BRCA_00067-T, BRCA_00067-N, 
/juno/work/taylorlab/biederstedte/sandbox/facetsTry13July2019/work/6a/f0cd6f0913ace26066272afe1fea8e/BRCA_00067-T.recal.bam, 
/juno/work/taylorlab/biederstedte/sandbox/facetsTry13July2019/work/03/c22295da3dbfa768028afbdafb5939/BRCA_00067-N.recal.bam, 
/juno/work/taylorlab/biederstedte/sandbox/facetsTry13July2019/work/6a/f0cd6f0913ace26066272afe1fea8e/BRCA_00067-T.recal.bam.bai, 
/juno/work/taylorlab/biederstedte/sandbox/facetsTry13July2019/work/03/c22295da3dbfa768028afbdafb5939/BRCA_00067-N.recal.bam.bai, 
/juno/work/taylorlab/biederstedte/sandbox/facetsTry13July2019/work/86/f36f0b2b6cd02e76f73ecc354e75b8/agilent-0009-scattered.interval_list]
```
Here is the current (incorrect) output to `bamFiles` in `develop`:


```
bamFiles.subscribe{ println it }

[w, a, BRCA_00117-T, BRCA_00117-N, /juno/work/taylorlab/biederstedte/sandbox/debug/work/00/fae52fd7b1de4dd3777e7af2a86799/BRCA_00117-T.recal.bam, 
/juno/work/taylorlab/biederstedte/sandbox/debug/work/84/48328177a7e989a3adb0aeb816f819/BRCA_00117-N.recal.bam, 
/juno/work/taylorlab/biederstedte/sandbox/debug/work/00/fae52fd7b1de4dd3777e7af2a86799/BRCA_00117-T.recal.bai, 
/juno/work/taylorlab/biederstedte/sandbox/debug/work/84/48328177a7e989a3adb0aeb816f819/BRCA_00117-N.recal.bai]0067-T, BRCA_00067-N, 
/juno/work/taylorlab/biederstedte/sandbox/debug/work/76/461fcb342100dd5f42fd665c0fd18a/BRCA_00067-T.recal.bam, /juno/wor

```

Given it is `w` and `a` as opposed to `wes` and `agilent`, this merge cannot happen correctly:

```
aMergedChannel = aBamList.combine(agilentIList, by: 1).unique() 
bMergedChannel = iBamList.combine(idtIList, by: 1).unique() 
wMergedChannel = wBamList.combine(wgsIList, by: 1).unique() 
```

Therefore,

```
item[3][0]  
item[4][0]  
```

is the bug, and I don't understand why it's there anyways.

I'm testing this here: `/juno/work/taylorlab/biederstedte/sandbox/fixRecalibrateBAM`

