### PR TITLE
revised check_for_duplicated_rows() to ignore empty lines

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -2539,13 +2539,17 @@ def returnFile(it) {
   return file(it)
 }
 
+
 def check_for_duplicated_rows(pairingFilePath) {
   def entries = []
   file( pairingFilePath ).eachLine { line ->
-    entries << line
+    if (!line.isEmpty()){
+      entries << line
+    }
   }
   return entries.toSet().size() == entries.size()
 }
+
 
 def check_for_mixed_assay(mappingFilePath) {
   def wgs = false


### PR DESCRIPTION
Should avoid issue whereby there are empty lines in the *tsv file. Groovy is funny like this. 