### PR TITLE
remove MafAnno in conf files

### DIFF
--- a/conf/resources.config
+++ b/conf/resources.config
@@ -101,10 +101,6 @@
     cpus = { 2 }
     memory = { 6.GB }
   }
-  withName:DoMafAnno {
-    cpus = { 2 }
-    memory = { 6.GB }
-  }
   withName:RunNeoantigen {
     cpus = { 2 }
     memory = { 6.GB }

--- a/conf/resources_aws.config
+++ b/conf/resources_aws.config
@@ -101,10 +101,6 @@
     cpus = { 4 }
     memory = { 8.GB }
   }
-  withName:DoMafAnno {
-    cpus = { 8 }
-    memory = { 32.GB }
-  }
   withName:RunNeoantigen {
     cpus = { 4 }
     memory = { 8.GB }

--- a/conf/resources_aws_genome.config
+++ b/conf/resources_aws_genome.config
@@ -97,10 +97,6 @@
     cpus = { 4 }
     memory = { 8.GB * task.attempt }
   }
-  withName:DoMafAnno {
-    cpus = { 8 }
-    memory = { 32.GB * task.attempt }
- } 
   withName:RunNeoantigen {
     cpus = { 8 }
     memory = { 32.GB * task.attempt }

--- a/conf/resources_juno.config
+++ b/conf/resources_juno.config
@@ -109,10 +109,6 @@
     cpus = { 4 }
     memory = { 2.MB * task.attempt }
   }
-  withName:DoMafAnno {
-    cpus = { 8 }
-    memory = { 4.MB * task.attempt }
-  }
   withName:RunNeoantigen {
     cpus = { 8 }
     memory = { 4.MB * task.attempt }

--- a/conf/resources_juno_genome.config
+++ b/conf/resources_juno_genome.config
@@ -109,11 +109,6 @@
     cpus = { 4 }
     memory = { 2.MB * task.attempt }
   }
-  withName:DoMafAnno {
-    cpus = { 8 }
-    memory = { 4.MB * task.attempt }
-    time = { 6.h * task.attempt }
- } 
   withName:RunNeoantigen {
     cpus = { 8 }
     memory = { 4.MB * task.attempt }


### PR DESCRIPTION
MafAnno is a process no longer used. This removes `MafAnno` from the config files. Otherwise, there is a warning:

`WARN: There's no process matching config selector: DoMafAnno`