### PR TITLE
Fix tool flags

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -1283,6 +1283,8 @@ process RunConpair {
     set file("${idNormal}.pileup"), file("${idTumor}.pileup") into conpairPileup
     set file("${idTumor}_${idNormal}_concordance.txt"), file("${idTumor}_${idNormal}_contamination.txt") into conpairOutput
 
+  when: !params.test
+
   script:
   gatkPath = "/usr/bin/GenomeAnalysisTK.jar"
   conpairPath = "/usr/bin/conpair"


### PR DESCRIPTION
I've standardized and cleaned up the conditional tool flags a bit. 

Some tool flags are overloaded in that they refer to the same tool used in both the somatic and germline workflow. At this point, I think we can consider removing the `--tools` argument–or think about how we can improve this in other ways. 