### PR TITLE
issue with targetIntervals

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -431,8 +431,8 @@ if (!params.bam_pairing) {
       targetIntervals = "${agilentTargetsList}"
     }
     if (target == 'idt'){
-      bait_intervals = "${idtBaitsList}"
-      target_intervals = "${idtTargetsList}"
+      baitIntervals = "${idtBaitsList}"
+      targetIntervals = "${idtTargetsList}"
     }
     """
     gatk CollectHsMetrics \


### PR DESCRIPTION
I noticed this causing errors here, e.g. `/juno/work/taylorlab/biederstedte/sandbox/bugfixLohhla4August2019_100WESTNpairsC/work/58/7f8b93f37946b02888cd3adf663c99`


Corrected this, which happened during our clean up:

```
    script:
    baitIntervals = ""
    targetIntervals = ""
    if (target == 'agilent'){
      baitIntervals = "${agilentBaitsList}"
      targetIntervals = "${agilentTargetsList}"
    }
    if (target == 'idt'){
      bait_intervals = "${idtBaitsList}"
      target_intervals = "${idtTargetsList}"
    }
    """
    gatk CollectHsMetrics \
      --INPUT ${bam} \
      --OUTPUT ${idSample}.hs_metrics.txt \
      --REFERENCE_SEQUENCE ${genomeFile} \
      --BAIT_INTERVALS ${baitIntervals} \
      --TARGET_INTERVALS ${targetIntervals} 
    """
  }
```