### PR TITLE
Use non-Spark GATK tools

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -324,12 +324,10 @@ if (!params.bam_pairing) {
     }
     memMultiplier = params.mem_per_core ? task.cpus : 1
     javaOptions = "--java-options '-Xmx" + task.memory.toString().split(" ")[0].toInteger() * memMultiplier + "g'"
-    sparkConf = "--conf 'spark.executor.cores = " + task.cpus + "'"
     knownSites = knownIndels.collect{ "--known-sites ${it}" }.join(' ')
     """
-    gatk BaseRecalibratorSpark \
+    gatk BaseRecalibrator \
       ${javaOptions} \
-      ${sparkConf} \
       --tmp-dir ${TMPDIR} \
       --reference ${genomeFile} \
       --known-sites ${dbsnp} \
@@ -375,11 +373,9 @@ if (!params.bam_pairing) {
     }
     memMultiplier = params.mem_per_core ? task.cpus : 1
     javaOptions = "--java-options '-Xmx" + task.memory.toString().split(" ")[0].toInteger() * memMultiplier + "g'"
-    sparkConf = "--conf 'spark.executor.cores = " + task.cpus + "'"
     """
-    gatk ApplyBQSRSpark \
+    gatk ApplyBQSR \
       ${javaOptions} \
-      ${sparkConf} \
       --tmp-dir ${TMPDIR} \
       --reference ${genomeFile} \
       --create-output-bam-index true \
@@ -494,10 +490,8 @@ if (!params.bam_pairing) {
         task.time = task.exitStatus != 140 ? { 6.h } : { 32.h }
       }
     }
-
     memMultiplier = params.mem_per_core ? task.cpus : 1
     javaOptions = "--java-options '-Xmx" + task.memory.toString().split(" ")[0].toInteger() * memMultiplier + "g'"
-
     baitIntervals = ""
     targetIntervals = ""
     if (target == 'agilent'){
@@ -552,7 +546,6 @@ if (!params.bam_pairing) {
         task.time = task.exitStatus != 140 ? { 6.h } : { 32.h }
       }
     }
-
     options = ""
     if (assay == "wes") {
       if (target == "agilent") options = "--bed ${agilentTargets}"


### PR DESCRIPTION
Based on #645, the Spark version of GATK tools cause some errors seemingly sporadic in nature.

It is possible that the enhanced performance of using Spark makes up for the increased failure rate overall. However, if the same sample hits the same "random" error three times it will not complete the rest of the pipeline.