### PR TITLE
fix scratch tmp fillup

### DIFF
--- a/conf/awsbatch.config.template
+++ b/conf/awsbatch.config.template
@@ -19,7 +19,7 @@ executor {
 
 process {
   queue = <AWS-BATCH-QUEUE-ARN>
-  scratch = '/scratch'
+  scratch = true
   errorStrategy = { task.attempt <= 3 ? 'retry' : 'ignore' }
   maxRetries = 3
 }
@@ -34,7 +34,7 @@ params {
 
 env {
   TMPDIR = '/scratch'
-  SPARK_LOCAL_DIRS = '/scratch'
+  SPARK_LOCAL_DIRS = './'
 }
 
 process {

--- a/conf/juno.config
+++ b/conf/juno.config
@@ -16,7 +16,7 @@ process {
   memory = "8.GB"
   time = { 3.h * task.attempt }
   clusterOptions = ""
-  scratch = "${TMPDIR}"
+  scratch = true
   beforeScript = "module load singularity/3.1.1; unset R_LIBS"
 }
 
@@ -31,5 +31,5 @@ params {
 }
 
 env {
-  SPARK_LOCAL_DIRS = "${TMPDIR}"
+  SPARK_LOCAL_DIRS = './'
 }

--- a/pipeline.nf
+++ b/pipeline.nf
@@ -301,7 +301,7 @@ if (!params.bam_pairing) {
     """
     gatk MarkDuplicates \
       ${javaOptions} \
-      --TMP_DIR ${TMPDIR} \
+      --TMP_DIR ./ \
       --MAX_RECORDS_IN_RAM 50000 \
       --INPUT ${idSample}.merged.bam \
       --METRICS_FILE ${idSample}.bam.metrics \
@@ -367,7 +367,6 @@ if (!params.bam_pairing) {
     gatk \
       ${sparkConf} \
       ${javaOptions} \
-      --tmp-dir ${TMPDIR} \
       --reference ${genomeFile} \
       --known-sites ${dbsnp} \
       ${knownSites} \
@@ -427,7 +426,6 @@ if (!params.bam_pairing) {
     gatk \
       ${sparkConf} \
       ${javaOptions} \
-      --tmp-dir ${TMPDIR} \
       --reference ${genomeFile} \
       --create-output-bam-index true \
       --bqsr-recal-file ${recalibrationReport} \


### PR DESCRIPTION
Fix scratch tmp fillup

Make all the `${TMPDIR}` related path to `./`, which equals to `${NXF_SCRATCH}` so that Nextflow can automatically clean it up when the process is done/aborted. 

Should eventually solve: 
https://github.com/mskcc/tempo/pull/637 
https://github.com/mskcc/tempo/pull/629
https://github.com/mskcc/tempo/pull/639