### PR TITLE
Feature/avoid duplicate normal run

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,9 @@
 # Installation
 
+::: tip Note
+Nextflow version 19.10.0 or later is **required**.
+:::
+
 ## Installing Nextflow
 [Nextflow](https://www.nextflow.io) requires Java 8 or later. You can check the version on your system with the command `java -version`.
 
@@ -8,8 +12,6 @@ Install Nextflow in the current directory by running:
 curl -s https://get.nextflow.io | bash
 ```
 Put the `nextflow` executable in a directory in your `PATH`, if you want to access it from anywhere. For more details, check out the [documentation](https://www.nextflow.io/docs/latest/getstarted.html).
-
-Nextflow version 19.10.0 or later is required.
 
 ## Installing Tempo
 Clone the [Tempo repository](http://github.com/mskcc/tempo):


### PR DESCRIPTION
1. When one normal sample is used to pair multiple tumor samples, the following processes will only run once for that normal (instead of repeating it for every T/N pair), and will start running right after the normal sample BAM is generated (instead of waiting for it's pairing tumor BAM is done):
⋅ GermlineDellyCall
⋅ GermlineRunManta
⋅ GermlineHaplotypecaller
⋅ GermlineRunStrelka2
⋅ RunPolysolver

2. Use `placeHolder` to replace idTumor for normal only processes' input channels to avoid re-ordering and re-mapping channel items

3. Change the name of final `maf` for somatic and germline

4. SomaticRunStrelka2 and SomaticCombineChannel use separate bam channel, see https://github.com/mskcc/tempo/issues/715