### PR TITLE
avoid bams to be truncated

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -472,7 +472,7 @@ if (!params.bamPairing) {
       --OUTPUT ${idSample}.md.tmp.bam
 
     mv ${idSample}.md.tmp.bam ${idSample}.md.bam
-    mv ${idSample}.md.tmp.bam.bai ${idSample}.md.bam.bai
+    mv ${idSample}.md.tmp.bai ${idSample}.md.bai
     """
   }
 


### PR DESCRIPTION
Trying to solve this: https://github.com/mskcc/tempo/issues/736

By distinguish the output file name (use `mv [tmp bam] [final bam]`) of the actual command and the output file name that declared in the Nextflow `output:` statement, Nextflow's output file existence checking mechanism will be triggered when LSF kills the job and gives a exit code 0, the `mv` command will never been executed, so the `[final bam]` is not exist, and Nextflow will complain about it and re-submit this job. This can make sure the output bam will always be the complete bam, after the command before `mv` was executed successfully.

HPC is working on figuring out why LSF gives wrong exit code in these cases. But so far this workaround solves this issue.

But it is not perfectly safe. We only triggered this check in 3 processes. Since we don’t know if this happens in other processes in the pipeline, whether the downstream process will complain when the input file is not complete. 