### PR TITLE
Revert "avoid bams to be truncated"

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -462,8 +462,7 @@ if (params.mapping && params.pairing) {
 
     script:
     """
-    samtools merge --threads ${task.cpus} ${idSample}.merged.tmp.bam ${bam.join(" ")}
-    mv ${idSample}.merged.tmp.bam ${idSample}.merged.bam
+    samtools merge --threads ${task.cpus} ${idSample}.merged.bam ${bam.join(" ")}
     """
   }
 
@@ -508,10 +507,7 @@ if (params.mapping && params.pairing) {
       --METRICS_FILE ${idSample}.bam.metrics \
       --ASSUME_SORT_ORDER coordinate \
       --CREATE_INDEX true \
-      --OUTPUT ${idSample}.md.tmp.bam
-
-    mv ${idSample}.md.tmp.bam ${idSample}.md.bam
-    mv ${idSample}.md.tmp.bai ${idSample}.md.bai
+      --OUTPUT ${idSample}.md.bam
     """
   }
 
@@ -630,13 +626,9 @@ if (params.mapping && params.pairing) {
       --create-output-bam-index true \
       --bqsr-recal-file ${recalibrationReport} \
       --input ${bam} \
-      --output ${idSample}.tmp.bam
-
-    mv ${idSample}.tmp.bam ${idSample}.bam
-    if [[ -f ${idSample}.tmp.bai ]]; then
-      mv ${idSample}.tmp.bai ${idSample}.bam.bai
-    else
-      mv ${idSample}.tmp.bam.bai ${idSample}.bam.bai
+      --output ${idSample}.bam
+    if [[ -f ${idSample}.bai ]]; then
+      mv ${idSample}.bai ${idSample}.bam.bai
     fi
     """
   }


### PR DESCRIPTION
meant to fix the bam truncation, which was proven not really solving the problem here 