### PR TITLE
bugfix/multi_part_per_lane_fastq

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -333,7 +333,17 @@ if (params.mapping) {
           tuple(idSample, target, fastqPairs, groupKey(fileID, laneCount), lanes)
         }
         .map{ idSample, target, fastqPairs, fileID, lane ->
-             [idSample, target, fastqPairs[0], fastqPairs[0].size(), fastqPairs[1], fastqPairs[1].size(), fileID, lane]
+             [idSample, target, fastqPairs[0], fastqPairs[1], fileID, lane]
+        }
+        .map{ item ->
+                idSample = item[0]
+                target = item[1]
+                fastqPair1 = item[2].toString().contains("_R1") ? item[2] : item[3]
+                fastqPair2 = item[3].toString().contains("_R2") ? item[3] : item[2]
+                fileID = item[4]
+                lane = item[5]
+
+             [idSample, target, fastqPair1, fastqPair1.size(), fastqPair2, fastqPair2.size(), fileID, lane]
         }
         .mix(fastqsNoNeedSplit)
   }


### PR DESCRIPTION
In some historical samples from IGO, there are some cases like below

```
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_007.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_006.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_005.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_004.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_010.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_002.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_012.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_009.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_008.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_003.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_001.fastq.gz
/ifs/archive/BIC/share/cmo/dmpwes1905/BRAD_0049_AC7A61ANXX/Project_6049/Sample_UD-cup-0357-N/UD-cup-0357-N_GTGAAA_L002_R1_011.fastq.gz
```

Prior to this fix, tempo will assume only 1 pair of fastq files per lane and didn't consider this situation. As a result, same bam names was given after align them separately which will end up have bams have the same name enter the `MergeBam` process and break it.

This fix it. TEMPO will align them separately and give different names to the bams and merge them.

This fix also considered the situation when multiple lanes are in the same fastq file but the fastq file was split into different part, although I don't think it should ever happen. It should look like:
```
SAMPLE_BARCODE_R1_001.fastq.gz
SAMPLE_BARCODE_R1_002.fastq.gz
SAMPLE_BARCODE_R1_003.fastq.gz
```

Also because of wildcard` "_+R1(?!.*R1)"` was changed to `_R1`, fastq names formatting with `SAMPLE_BARCODE.R1.fastq.gz` will not be supported anymore

This PR also fixed the id in the `file-size.txt` file so that it matches the `TAG` in different process for performance report script to work.