### PR TITLE
initialize pairingQc variable and set pairingQc to true when --QC par…

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -92,6 +92,8 @@ runConpairAll = false
 
 println ""
 
+pairingQc = params.pairing
+
 if (params.mapping || params.bamMapping) {
   TempoUtils.checkAssayType(params.assayType)
   if (params.watch == false) {
@@ -104,7 +106,9 @@ if (params.mapping || params.bamMapping) {
   }
   else{}
   if(params.pairing){
-    pairingQc = params.pairing
+    if(runQC){
+      pairingQc = true
+    }
     if (params.watch == false) {
       pairingFile = file(params.pairing, checkIfExists: true)
       (checkPairing1, checkPairing2, inputPairing) = TempoUtils.extractPairing(pairingFile).into(3)


### PR DESCRIPTION
addressing issue #775 where pairingQC is not set, preventing us from running `--mapping`/`--bamMapping` with  `--QC` alone. 