### PR TITLE
handling all homozygous or no suitable HLA and in lohhla

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -1659,7 +1659,7 @@ process RunLOHHLA {
     set file(hlaFasta), file(hlaDat) from Channel.value([referenceMap.hlaFasta, referenceMap.hlaDat])
 
   output:
-    set file("*.DNA.HLAlossPrediction_CI.txt"), file("*DNA.IntegerCPN_CI.txt"), file("*.pdf"), file("*.RData") into lohhlaOutput
+    set file("*.DNA.HLAlossPrediction_CI.txt"), file("*DNA.IntegerCPN_CI.txt"), file("*.pdf"), file("*.RData") optional true into lohhlaOutput
     set val("placeHolder"), idTumor, idNormal, file("*.DNA.HLAlossPrediction_CI.txt") into predictHLA4Aggregate
     set val("placeHolder"), idTumor, idNormal, file("*DNA.IntegerCPN_CI.txt") into intCPN4Aggregate
 


### PR DESCRIPTION
When `All HLA alleles are homozygous or no suitable HLA. No LOH analysis can be performed.`, remove `*.All_HLA_alleles_homozygous.DNA.HLAlossPrediction_CI.txt` and `*No_Suitable_HLA_alleles.DNA.HLAlossPrediction_CI.txt`