### PR TITLE
change columns for facetsSuite 2.x gene level aggregate

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -3240,7 +3240,7 @@ process SomaticAggregateFacets {
   awk 'FNR==1 && NR!=1{next;}{print}' facets_tmp/*_OUT.txt > cna_facets_run_info.txt
   mv *{gene_level,arm_level}.txt facets_tmp/
   cat facets_tmp/*gene_level.txt | head -n 1 > cna_genelevel.txt
-  awk -v FS='\t' '{ if (\$16 != "DIPLOID" && (\$17 == "PASS" || (\$17 == "FAIL" && \$18 == "rescue")))  print \$0 }' facets_tmp/*gene_level.txt >> cna_genelevel.txt
+  awk -v FS='\t' '{ if (\$24 != "DIPLOID" && (\$25 == "PASS" || \$25 == "RESCUE" ))  print \$0 }' facets_tmp/*gene_level.txt >> cna_genelevel.txt
   cat facets_tmp/*arm_level.txt | head -n 1 > cna_armlevel.txt
   cat facets_tmp/*arm_level.txt | grep -v "DIPLOID" | grep -v "Tumor_Sample_Barcode" >> cna_armlevel.txt || [[ \$? == 1 ]]
   """


### PR DESCRIPTION
Change columns for facetsSuite 2.x gene level aggregate.

https://github.com/mskcc/facets-suite/blob/master/R/gene-level-changes.R#L125

`cn_state` is column number 24 now.

“rescue” is now “RESCUE” in `filter` column, number 25. No `review` column anymore.

Aggregate now include `PASS` and `RESCUE` from column 25 of the `*.gene_level.txt`. Excluding `suppress_large_homdel `.