### PR TITLE
hotfix of QcQualimap memory limit and update of container image version

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -49,7 +49,7 @@
     container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.0"
   }
   withName:SomaticCombineChannel {
-    container = "cmopipeline/bcftools-vt:1.2.1"
+    container = "cmopipeline/bcftools-vt:1.2.2"
   }
   withName:SomaticAnnotateMaf {
     container = "cmopipeline/vcf2maf:vep88_1.2.3"
@@ -101,7 +101,7 @@
     container = "cmopipeline/strelka2_manta:latest"
   }
   withName:GermlineCombineChannel {
-    container = "cmopipeline/bcftools-vt:1.2.1"
+    container = "cmopipeline/bcftools-vt:1.2.2"
   }
   withName:GermlineAnnotateMaf {
     container = "cmopipeline/vcf2maf:vep88_1.2.3"

--- a/conf/resources.config
+++ b/conf/resources.config
@@ -172,7 +172,7 @@
   }
   withName:QcQualimap {
     cpus = { 2 }
-     memory = { 6.GB }
+    memory = { task.attempt < 3 ? 6.GB * task.attempt : 12.GB * task.attempt }
   }
   withName:QcCollectHsMetrics {
     cpus = { 2 }

--- a/conf/resources_aws.config
+++ b/conf/resources_aws.config
@@ -172,7 +172,7 @@
   }
   withName:QcQualimap {
     cpus = { 2 }
-    memory = { 3.GB * task.attempt }
+    memory = { task.attempt < 3 ? 3.GB * task.attempt : 6.GB * task.attempt }
   }
   withName:QcCollectHsMetrics {
     cpus = { 1 }

--- a/conf/resources_aws_genome.config
+++ b/conf/resources_aws_genome.config
@@ -172,7 +172,7 @@
   }
   withName:QcQualimap {
     cpus = { 2 }
-    memory = { 6.GB * task.attempt }
+    memory = { task.attempt < 3 ? 6.GB * task.attempt : 12.GB * task.attempt }
   }
 
 //------------- Cohort Aggregation

--- a/conf/resources_juno.config
+++ b/conf/resources_juno.config
@@ -172,7 +172,7 @@
   }
   withName:QcQualimap {
     cpus = { 2 }
-    memory = { 3.GB * task.attempt }
+    memory = { task.attempt < 3 ? 3.GB * task.attempt : 6.GB * task.attempt }
   }
   withName:QcCollectHsMetrics {
     cpus = { 1 }

--- a/conf/resources_juno_genome.config
+++ b/conf/resources_juno_genome.config
@@ -183,7 +183,7 @@
   }
   withName:QcQualimap {
     cpus = { 2 }
-    memory = { 6.GB * task.attempt }
+    memory = { task.attempt < 3 ? 6.GB * task.attempt : 12.GB * task.attempt }
   }
 
 //------------- Cohort Aggregation


### PR DESCRIPTION
1. Updated QcQualimap to use more resources during the fourth try in hopes that it doesn't run out of memory
2. Update image of `SomaticCombineChannel` and `GermlineCombineChannel` to most current, `cmopipeline/bcftools-vt:1.2.2`.

These updates are only expected to ensure completion of processes. Neither are expected to change the content of existing results.