### PR TITLE
enhancement/write cache and memory management for Qualimap and Facets

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -2586,8 +2586,6 @@ process QcQualimap {
   output:
     set idSample, file("${idSample}_qualimap_rawdata.tar.gz") into qualimap4MultiQC, qualimap4Aggregate
     set idSample, file("*.html"), file("css/*"), file("images_qualimapReport/*") into qualimapOutput
-    file("fileslist.txt") into filesout
-
   
   when: runQC   
 


### PR DESCRIPTION
A few optimizations in `Qualimap`/`DoFacets`/`DoFacetsPreviewQC` for resource usage and cache of results.
- Tempodeliver works best when we are able to automatically assign permissions to the output files using inherited ACLs. However, inheritance has recently caused failure due to setting entire directories as `output` in the `QcQualimap` and `DoFacets` steps. The downstream steps of `Qualimap`/`DoFacets` require the directory structure to be preserved in the input channel so i handled this in two ways:
  - `DoFacets` and `DoFacetsPreviewQC` collapsed into one step. 
  - Raw results of `QcQualimap` that are needed for `CohortMultiQC` were compressed into a `.tar.gz` file and extracted in the next process. these raw results are expected to be small in size and take an insignficant amount of time to extract. 
- Followed Qualimap [guidelines](https://hpc.nih.gov/docs/QualimapManual.pdf) in order to improve memory usage, including: 
  - lowering heap-size compared to total task memory so that there is some room to expand beyond heap-size when the JVM requires it without causing failure
  - increasing threads with the assumption that there are at least two cores per cpu, and two threads per core: `-nt ${ ( task.cpus * 4 ) - 1 }`
  - lowering number of windows (qualimap parameter)
  - lowering size of read chunks (qualimap parameter)