### PR TITLE
Use new neoantigen docker

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -76,7 +76,7 @@
     container = "cmopipeline/facets-suite-preview-htstools:0.0.1"
   } 
   withName:RunNeoantigen {
-    container = "cmopipeline/neoantigen:0.3.2"
+    container = "cmopipeline/neoantigen:0.3.2-hotfix"
   }
   withName:MetaDataParser {
     container = "cmopipeline/metadataparser:0.5.7"

--- a/containers/neoantigen/Dockerfile
+++ b/containers/neoantigen/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Allan Bolipata <bolipatc@mskcc.org>, Evan Biederstedt <evan.biederstedt@gmail.com>, Yixiao Gong <gongy@mskcc.org>" \
-    version.image="0.3.2" \
-    version.neoantigen-dev="0.3.2" \
+    version.image="0.3.2-hotfix" \
+    version.neoantigen-dev="0.3.2-hotfix" \
     version.netMHC="4.0a" \
     version.netMHCpan="4.0a" \
     version.python="2.7.15rc1"
 
 ENV TMPDIR="/tmp"
-ENV NEOANTIGEN_VERSION 0.3.2
+ENV NEOANTIGEN_VERSION 0.3.2-hotfix
 
 RUN apt-get update && apt-get install -y \
     tcsh \


### PR DESCRIPTION
A new tag (similar to a release but not quite) for `taylor-lab/neoantigen-dev` was created and includes a bugfix for #838 . This hotfix was created by:
1. checking out a new branch starting from the 0.3.2 release, which is the latest `neoantigen-dev` release and what we’re using for tempo currently
2. adding and commiting hotfix that is the same as the solution in https://github.com/taylor-lab/neoantigen-dev/pull/13#issue-534782054
3. publish `0.3.2-hotfix` 

Then i changed the `Dockerfile` in the tempo repo to point to  `0.3.2-hotfix`, built the docker, and configured tempo to use the new container after it was pushed to dockerhub. 

This was confirmed to work in the small fastq tests, and produced the same md5sums. I also tested with two clinical pairs, including one that was mentioned in #838 