### PR TITLE
change permissions for DoFacetsPreviewQC to execute on folder

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -1655,7 +1655,7 @@ process DoFacetsPreviewQC {
   for i in "\${facetsFitFiles[@]}" ; do 
     cp \$i ${facetsOutputDir}/\$i
   done
-  chmod -R ug+rw ${facetsOutputDir}/*
+  chmod -R u+rw ${facetsOutputDir}/*
   echo -e "sample_id\\tsample_path\\ttumor_id" > manifest.txt 
   echo -e "${idTumor}__${idNormal}\\t\$(pwd)\\t${idTumor}" >> manifest.txt 
   gzip manifest.txt


### PR DESCRIPTION
To address an issue with FacetsPreviewQc being unable to read or write to temporary facets directory, I've made a small change to ensure permissions to read and write: `chmod -R ug+rw`.

I didn't encounter this issue until I ran tempo on `/juno/work/tempo`, where we have some ACL presets that may have interacted weirdly with the staged directory in `/scratch`. The error I can see in `.command.log` is:
```
> facetsPreview::generate_genomic_annotations('s_C_6K207K_P001_d__s_C_6K207K_N001_d', '/scratch/tempobot/nxf.XpaVYRguiP/', '/usr/bin/facets-preview/tempo_config.json')
Error in file(con, "r") : cannot open the connection
Calls: <Anonymous> ... %>% -> eval -> eval -> metadata_init -> readLines -> file
In addition: There were 35 warnings (use warnings() to see them)
Execution halted
```
doing `chmod -R u+r` was not enough, as we got the following error:
```
Error in file(file, ifelse(append, "a", "w")) : 
  cannot open the connection
Calls: <Anonymous> ... loop_apply -> <Anonymous> -> .fun -> write.table -> file
In addition: There were 35 warnings (use warnings() to see them)
Execution halted
```