### PR TITLE
bugfix/raised resources of RunMsiSensor in advanced attempts

### DIFF
--- a/conf/resources_juno.config
+++ b/conf/resources_juno.config
@@ -82,7 +82,7 @@
   }
   withName:RunMsiSensor {
     cpus = { 1 }
-    memory = { task.attempt < 3 ? 2.GB * task.attempt : 4.GB * task.attempt }
+    memory = { task.attempt < 3 ? 2.GB * task.attempt : 6.GB * task.attempt }
   }
   withName:RunPolysolver {
     cpus = { 8 }


### PR DESCRIPTION
We have one exome sample in the repo that continues to fail `RunMsiSensor` at a memory allotment of 16 gb with the following message:
```
TERM_MEMLIMIT: job killed after reaching LSF memory usage limit.
```

This PR will raise the maximum memory limit to 24 Gb on the 4th attempt. This should address the arrested sample and any similar ones that arise. 