### PR TITLE
add facets base image to tempo repo 

### DIFF
--- a/containers/facets-suite-preview/Dockerfile
+++ b/containers/facets-suite-preview/Dockerfile
@@ -1,0 +1,73 @@
+FROM rocker/tidyverse:3.6.1
+
+LABEL maintainer="Anne Marie Noronha (noronhaa@mskcc.org)" \
+	contributor="Yixiao Gong (gongy@mskcc.org)" \
+	contributor="Nikhil Kumar (kumarn1@mskcc.org)" \
+	contributor="Philip Jonsson (jonssonp@mskcc.org)" \
+	version.image="0.0.1-rebuild" \
+	version.facets_suite="2.0.8" \
+	version.facets="0.5.14" \
+	version.alpine="3.8" \
+	version.pctGCdata="0.2.0" \
+	source.facets="https://github.com/mskcc/facets/archive/v0.5.14.tar.gz" 
+
+ENV FACETS_SUITE_VERSION 2.0.8
+ENV FACETS_VERSION 0.5.14
+ENV FACETS_PREVIEW_VERSION 2.1.4
+ENV PCTGCDATA 0.2.0
+
+# Requirements
+RUN apt-get update \
+	&& apt-get install -y \
+	g++ \
+	tar \
+	bzip2 \
+	libbz2-dev \
+	libc6-dev \
+	libxt-dev \
+	liblzma-dev \
+	libgtk2.0-dev \
+	libcairo2-dev \
+	xvfb \
+	xauth \
+	xfonts-base
+RUN apt-get install -y xdg-utils --fix-missing
+RUN apt-get install -y inotify-tools=3.14-2
+
+RUN R -e "install.packages(c('Cairo','argparse','gridExtra', 'binom', 'BiocManager', 'diptest', 'egg','shinyWidgets', 'shinyjs', 'rhandsontable', 'doParallel', 'configr', 'R.utils'), repos='http://cran.us.r-project.org')" \
+	&& R -e "BiocManager::install('rtracklayer')"
+
+# Install FACETS, pctGCdata and facets-suite
+RUN cd /tmp \
+	&& wget https://github.com/mskcc/facets-suite/archive/${FACETS_SUITE_VERSION}.tar.gz -O facets-suite-${FACETS_SUITE_VERSION}.tar.gz \
+	&& wget https://github.com/mskcc/facets/archive/v${FACETS_VERSION}.tar.gz -O facets-v${FACETS_VERSION}.tar.gz \
+	&& wget https://github.com/mskcc/pctGCdata/archive/v${PCTGCDATA}.tar.gz \
+	&& git clone --single-branch --branch master https://github.com/taylor-lab/facets-preview.git facets-preview-master \
+	&& tar xvzf facets-v${FACETS_VERSION}.tar.gz \
+	&& tar xvzf v${PCTGCDATA}.tar.gz \
+	&& tar xvzf facets-suite-${FACETS_SUITE_VERSION}.tar.gz \
+	&& cd /tmp/pctGCdata-${PCTGCDATA} \
+	&& R CMD INSTALL . \
+	&& cd /tmp/facets-${FACETS_VERSION} \
+	&& R CMD INSTALL . \
+	&& cd /tmp/facets-suite-${FACETS_SUITE_VERSION} \
+	&& R CMD INSTALL . \
+	# correct shebang line
+	&& sed -i "s/opt\/common\/CentOS_6-dev\/R\/R-3.2.2\//usr\//g" *.R \
+	# copy execs to /usr/bin/facets-suite
+	&& mkdir -p /usr/bin/facets-suite/ \
+	&& cp -r /tmp/facets-suite-${FACETS_SUITE_VERSION}/* /usr/bin/facets-suite/ \
+	&& cd /tmp/facets-preview-master \
+	&& R CMD INSTALL . \
+	&& mkdir -p /usr/bin/facets-preview/ \
+	&& cp -r /tmp/facets-preview-master/* /usr/bin/facets-preview/ \
+	# clean up
+	&& rm -rf /var/cache/apk/* /tmp/* # update to using release version when 2.1.5+ is released.
+
+ENV PYTHONNOUSERSITE set
+ENV FACETS_OVERRIDE_EXITCODE set
+
+COPY impact_juno_config.json /usr/bin/facets-preview/
+RUN chmod 744 /usr/bin/facets-preview/impact_juno_config.json
+EXPOSE 3838
+

--- a/containers/facets-suite-preview/impact_juno_config.json
+++ b/containers/facets-suite-preview/impact_juno_config.json
@@ -1,0 +1,23 @@
+{
+	"repo": [
+		{
+			"name": "Clinical series IMPACT",
+			"manifest_file": "/juno/work/ccs/shared/resources/impact/facets/manifests/impact_facets_manifest_latest.txt.gz",
+			"tumor_id_format": "^P-\\d{7}-T\\d+-IM\\d(,P-\\d{7}-T\\d+-IM\\d)*$",
+			"counts_file_format": "countsMerged____{sample_id}.dat.gz"
+	        }
+	],
+	"watcher_dir": "/juno/work/ccs/shared/software/refit_watcher/",
+	"facets_lib": [
+		{
+			"version": "0.5.14",
+			"lib_path": "/usr/local/lib/R/site-library/facets/"
+		}
+	],
+	"verify_sshfs_mount" : "",
+	"r_script_path" : "/usr/local/bin/Rscript",
+	"facets_suite_lib": "/usr/local/lib/R/site-library/",
+	"facets_suite_run_wrapper": "/usr/bin/facets-suite/run-facets-wrapper.R",
+	"facets_qc_script": "/usr/bin/facets-preview/facets_qc/v1.0/facets_fit_qc.R"
+}
+


### PR DESCRIPTION
Recreating the facets base image that is named `cmopipeline/facets-suite-preview:0.0.1` in dockerhub, now named `cmopipeline/facets-suite-preview:0.0.1-rebuild`. 

I tried to recreate as closely to the original as I could using information on Dockerhub. There are a few tweaks to the original:
1. installation of `inotify-tools`. In the event that the refit_watcher is not accessible, this installation should make it possible to set up and run your own daemon using the image (un-tested)
2. adjustment of the "example" config file. The config file is now set up to help you run facets-preview with the image directly on juno, on the IMPACT repo (named `impact_juno_config.json`), without necessarily changing the file contents. This is intended as an improvement from the original `tempo_config.json`, which was intended to run on local machines such as Mac OSX and often required adjustment for each host environment.