### PR TITLE
QcAlfred target bugfix

### DIFF
--- a/modules/process/QC/QcAlfred.nf
+++ b/modules/process/QC/QcAlfred.nf
@@ -28,7 +28,7 @@ process QcAlfred {
 
   options = ""
   if (params.assayType == "exome") {
-    if (target == "agilent") options = "--bed ${targets}"
+    options = "--bed ${targets}"
   }
   def ignore = ignore_rg ? "--ignore" : ""
   def outfile = ignore_rg ? "${idSample}.alfred.tsv.gz" : "${idSample}.alfred.per_readgroup.tsv.gz"

--- a/pipeline.nf
+++ b/pipeline.nf
@@ -2660,7 +2660,7 @@ process QcAlfred {
 
   options = ""
   if (params.assayType == "exome") {
-    if (target == "agilent") options = "--bed ${targets}"
+    options = "--bed ${targets}"
   }
   def ignore = ignore_rg ? "--ignore" : ""
   def outfile = ignore_rg ? "${idSample}.alfred.tsv.gz" : "${idSample}.alfred.per_readgroup.tsv.gz"


### PR DESCRIPTION
bugfix so that bed files are used for all samples that are exome in QcAlfred. Addresses #953 