### PR TITLE
bugfix for single bam input into MergeBamsAndMarkDuplicates

### DIFF
--- a/modules/process/Alignment/MergeBamsAndMarkDuplicates.nf
+++ b/modules/process/Alignment/MergeBamsAndMarkDuplicates.nf
@@ -11,7 +11,7 @@ process MergeBamsAndMarkDuplicates {
   script:
 
   bamSize = 0
-  bam.each{ bamSize = bamSize + it.size()}
+  [bam].flatten().each{ bamSize = bamSize + it.size()}
 
   if (workflow.profile == "juno") {
     if(bamSize > 100.GB) {


### PR DESCRIPTION
Added on bugfix for error related to single bam input, related to issue #952 and PR #955 . In the previous PR, `bam` is input as a list, however if it is a one-element list then it is coerced to `bam[0]`. In this PR it is coerced back with `[bam].flatten().each{ bamSize = bamSize + it.size()}`. If `bam` is already a list of filepaths it will remain as such, if `bam` is a filepath then it becomes a list of filepaths.