### PR TITLE
Fix malformed Strelka VCFs

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -40,7 +40,7 @@
     container = "cmopipeline/iannotatesv:0.0.2" 
   }
   withName:"SomaticRunStrelka2.*" {
-    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.0"
+    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.1"
   }
   withName:SomaticCombineChannel {
     container = "cmopipeline/bcftools-vt:1.2.3"
@@ -82,7 +82,7 @@
     container = "cmopipeline/delly-bcftools:0.0.1"
   }
   withName:SomaticRunManta {
-    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.0"
+    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.1"
   }
   withName: '.*RunSvABA' {
     container = "cmopipeline/svaba:0.0.1"
@@ -124,10 +124,10 @@
     container = "cmopipeline/bcftools-vt:1.1.1"
   }
   withName:GermlineRunManta {
-    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.0"
+    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.1"
   }
   withName:"GermlineRunStrelka2" {
-    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.0"
+    container = "cmopipeline/strelka2-manta-bcftools-vt:2.0.1"
   }
   withName:GermlineCombineChannel {
     container = "cmopipeline/bcftools-vt:1.2.2"

--- a/containers/strelka2-manta-bcftools-vt/Dockerfile
+++ b/containers/strelka2-manta-bcftools-vt/Dockerfile
@@ -1,8 +1,9 @@
 FROM nfcore/base:latest
 
 LABEL \
-  authors="Yixiao Gong (gongy@mskcc.org)"
-  version.image="2.0.0"
+  authors="Yixiao Gong (gongy@mskcc.org)" \
+  contributors="Anne Marie Noronha (noronhaa@mskcc.org)" \
+  version.image="2.0.1"
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a

--- a/containers/strelka2-manta-bcftools-vt/environment.yml
+++ b/containers/strelka2-manta-bcftools-vt/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pysam=0.15.2
   - strelka=2.9.10
   - manta=1.5.0
+  - bioconda::vcftools=0.1.16

--- a/modules/process/GermSNV/GermlineRunStrelka2.nf
+++ b/modules/process/GermSNV/GermlineRunStrelka2.nf
@@ -30,5 +30,7 @@ process GermlineRunStrelka2 {
 
   mv Strelka/results/variants/variants.vcf.gz ${idNormal}.strelka2.vcf.gz
   mv Strelka/results/variants/variants.vcf.gz.tbi ${idNormal}.strelka2.vcf.gz.tbi
+
+  if [ \$(vcf-validator ${idNormal}.strelka2.vcf.gz 2>&1 | wc -l ) -gt 0 ] ; then exit 1 ; fi
   """
 }

--- a/modules/process/SNV/SomaticRunStrelka2.nf
+++ b/modules/process/SNV/SomaticRunStrelka2.nf
@@ -58,5 +58,7 @@ process SomaticRunStrelka2 {
     --output ${outfile}
 
   tabix --preset vcf ${outfile}
+
+  if [ \$(vcf-validator ${outfile} 2>&1 | wc -l ) -gt 0 ] ; then exit 1 ; fi
   """
 }


### PR DESCRIPTION
Adding vcf-validator check at the end of `GermlineRunStrelka2` and `SomaticRunStrelka2` processes to prevent downstream issues. When vcf-validator finds issues, the processes exits with an error and triggers a retry. This PR should close #887 and #903