### PR TITLE
define intermediates_dir for rmarkdown rendering

### DIFF
--- a/containers/biocircos/generate_biocircos.R
+++ b/containers/biocircos/generate_biocircos.R
@@ -145,4 +145,5 @@ gen.plot.biocircos <- function(bedpe,cnv,sample_name,genome_v){
 }
 
 plot.biocircos <- gen.plot.biocircos(bedpe=bedpe,cnv=cnv,sample_name = opt$sampleName, genome_v=genome_v )
-rmarkdown::render("biocircos.Rmd", "all", paste0(opt$sampleName,".circos.html"), output_dir='.')
+rmarkdown::render("biocircos.Rmd", "all", paste0(opt$sampleName,".circos.html"), output_dir='.',intermediates_dir='./tmp')
+unlink('./tmp',recursive=TRUE)


### PR DESCRIPTION
Fixes #984 
`intermediates_dir` is now a tmp folder in the current directory where we know we will have write permissions. 