### PR TITLE
moved process directives that use dot (.) notation to a process closure

### DIFF
--- a/conf/juno.config
+++ b/conf/juno.config
@@ -18,10 +18,9 @@ process {
   clusterOptions = ""
   scratch = true
   beforeScript = "module load singularity/3.1.1; unset R_LIBS; catch_term () { echo 'caught USR2/TERM signal'; set +e; false; on_exit ; } ; trap catch_term USR2 TERM"
+  maxRetries = 3
+  errorStrategy = { task.attempt <= process.maxRetries ? 'retry' : 'ignore' }
 }
-
-process.maxRetries = 3
-process.errorStrategy = { task.attempt <= process.maxRetries ? 'retry' : 'ignore' }
 
 params {
   max_memory = "128.GB"


### PR DESCRIPTION
Addresses the 2nd point in #978 (but does not close the issue). the process directive that use dot notation (.) have been moved to inside of a `process { }` closure, therefore providing a workaround for the bug that is described here: https://github.com/nextflow-io/nextflow/issues/3154