### PR TITLE
fix empty bedpe

### DIFF
--- a/containers/iannotatesv/run_iannotatesv.py
+++ b/containers/iannotatesv/run_iannotatesv.py
@@ -61,7 +61,10 @@ def main():
 	pool.close()
 	pool.join()
 
-	iAnnotate_output = pd.concat(map(read_iannotatesv_result, [os.path.join("outputs","output_" + str(i) + "_Annotated.txt") for i in range(n_chunks)]))
+	try:
+		iAnnotate_output = pd.concat(map(read_iannotatesv_result, [os.path.join("outputs","output_" + str(i) + "_Annotated.txt") for i in range(n_chunks)]))
+	except ValueError as ve:
+		iAnnotate_output = pd.DataFrame(columns=key_col.keys())
 	for key,val in key_col.items():
 		iAnnotate_output[key] = iAnnotate_output[key].astype(val)
 

--- a/modules/process/SV/SomaticRunClusterSV.nf
+++ b/modules/process/SV/SomaticRunClusterSV.nf
@@ -26,7 +26,8 @@ process SomaticRunClusterSV {
   mkdir -p tmp
   grep -v "^#" ${bedpe} | cut -f 1-10 > tmp/${outputPrefix}.bedpe
   if [ \$(cat tmp/${outputPrefix}.bedpe | wc -l ) -lt 1 ] ; then
-    touch tmp/${outputPrefix}.sv_clusters_and_footprints.tsv
+    touch ${outputPrefix}.sv_clusters_and_footprints.tsv
+    touch ${outputPrefix}.sv_distance_pvals
   else
     Rscript /opt/ClusterSV/R/run_cluster_sv.R \\
       -chr /opt/ClusterSV/references/${genome_}.chrom_sizes \\

--- a/modules/process/SV/SomaticSVVcf2Bedpe.nf
+++ b/modules/process/SV/SomaticSVVcf2Bedpe.nf
@@ -26,7 +26,7 @@ process SomaticSVVcf2Bedpe {
     -t ${outputPrefix}_tmp
 
   if [ ! -s ${outputPrefix}.combined.tmp.bedpe ] ; then
-    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tTUMOR\\tNORMAL\\tTUMOR_ID\\tNORMAL_ID" >> ${outputPrefix}.combined.tmp.bedpe
+    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tTUMOR\\tNORMAL" >> ${outputPrefix}.combined.tmp.bedpe
   fi
 
   zgrep "^##" ${vcfFile} | sed "s/##fileformat=*/##fileformat=BEDPE/g" > ${outputPrefix}.combined.unsorted.bedpe

--- a/modules/process/SV/SomaticSVVcf2Bedpe.nf
+++ b/modules/process/SV/SomaticSVVcf2Bedpe.nf
@@ -25,14 +25,14 @@ process SomaticSVVcf2Bedpe {
     -o ${outputPrefix}.combined.tmp.bedpe \\
     -t ${outputPrefix}_tmp
 
+  if [ ! -s ${outputPrefix}.combined.tmp.bedpe ] ; then
+    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tTUMOR\\tNORMAL\\tTUMOR_ID\\tNORMAL_ID" >> ${outputPrefix}.combined.tmp.bedpe
+  fi
+
   zgrep "^##" ${vcfFile} | sed "s/##fileformat=*/##fileformat=BEDPE/g" > ${outputPrefix}.combined.unsorted.bedpe
   grep -v "^##" ${outputPrefix}.combined.tmp.bedpe | \\
-  awk -F"\\t" -v tid="${idTumor}" -v nid="${idNormal}" -v OFS="\\t" 'NR == 1 {print \$0,"TUMOR_ID","NORMAL_ID";next;}{print \$0,tid,nid}' \\
-  >> ${outputPrefix}.combined.unsorted.bedpe
-
-  if [ ! -s ${outputPrefix}.combined.unsorted.bedpe ] ; then 
-    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tTUMOR\\tNORMAL\\tTUMOR_ID\\tNORMAL_ID" >> ${outputPrefix}.combined.unsorted.bedpe
-  fi
+    awk -F"\\t" -v tid="${idTumor}" -v nid="${idNormal}" -v OFS="\\t" 'NR == 1 {print \$0,"TUMOR_ID","NORMAL_ID";next;}{print \$0,tid,nid}' \\
+    >> ${outputPrefix}.combined.unsorted.bedpe
 
   svtools bedpesort \\
     ${outputPrefix}.combined.unsorted.bedpe \\


### PR DESCRIPTION
This PR fixes an issue with empty bedpe files. Previously, a bedpe that has no variant calls was produced without a header, which causes issues down the line with reading the bedpe file. Now a bedpe file with no variants is produced with a header line, and any downstream issues have been corrected.