### PR TITLE
update netlify documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Tempo is a CMO Computational Sciences (CCS) research pipeline processing WES & WGS tumor-normal pairs using the [Nextflow framework](https://www.nextflow.io/). Currently the pipeline is composed of alignment and QC, and detection of both somatic alterations and germline variants. Users can begin with inputs of either paired-end FASTQs or BAMs, and process these via the command line. 
 
-For further details of how to begin processing data with Tempo, please view our [documentation](https://ccstempo.netlify.com/). For contributing to this project, please make a pull request as detailed [here](https://ccstempo.netlify.com/contributing-to-tempo.html).
+For further details of how to begin processing data with Tempo, please view our [documentation](https://cmotempo.netlify.com/). For contributing to this project, please make a pull request as detailed [here](https://cmotempo.netlify.com/contributing-to-tempo.html).
 
 The inspiration for this project derives from [Sarek](https://github.com/SciLifeLab/Sarek), developed at [SciLifeLab](https://github.com/SciLifeLab).
 


### PR DESCRIPTION
The current readme on the master branch has an out of date link for the netlify hosted documentation. This PR replaces that one with the new link. 