### PR TITLE
allow storeDir for RunBQSR

### DIFF
--- a/pipeline.nf
+++ b/pipeline.nf
@@ -660,15 +660,15 @@ if (params.mapping) {
     """
   }
 
-  File file = new File(outname)
-  file.newWriter().withWriter { w ->
+  File file_bammapping = new File(outname)
+  file_bammapping.newWriter().withWriter { w ->
       w << "SAMPLE\tTARGET\tBAM\tBAI\n"
   }
 
   bamResults.map{ idSample, target, bam, bai ->
       [ idSample, target, "${file(outDir).toString()}/bams/${idSample}/${idSample}.bam", "${file(outDir).toString()}/bams/${idSample}/${idSample}.bam.bai" ]
   }.subscribe { Object obj ->
-      file.withWriterAppend { out ->
+      file_bammapping.withWriterAppend { out ->
           out.println "${obj[0]}\t${obj[1]}\t${obj[2]}\t${obj[3]}"
       }
   }

--- a/pipeline.nf
+++ b/pipeline.nf
@@ -581,8 +581,7 @@ if (params.mapping) {
         referenceMap.knownIndelsIndex 
       ])
     output:
-      set idSample, target, file("${idSample}.bam"), file("${idSample}.bam.bai") into bamsBQSR4Alfred, bamsBQSR4CollectHsMetrics, bamsBQSR4Tumor, bamsBQSR4Normal, bamsBQSR4QcPileup, bamsBQSR4Qualimap
-      set idSample, target, val("${file(outDir).toString()}/bams/${idSample}/${idSample}.bam"), val("${file(outDir).toString()}/bams/${idSample}/${idSample}.bam.bai") into bamResults
+      set idSample, target, file("${idSample}.bam"), file("${idSample}.bam.bai") into bamsBQSR4Alfred, bamsBQSR4CollectHsMetrics, bamsBQSR4Tumor, bamsBQSR4Normal, bamsBQSR4QcPileup, bamsBQSR4Qualimap, bamResults
       file("file-size.txt") into bamSize
     script:
     if (workflow.profile == "juno") {
@@ -666,7 +665,9 @@ if (params.mapping) {
       w << "SAMPLE\tTARGET\tBAM\tBAI\n"
   }
 
-  bamResults.subscribe { Object obj ->
+  bamResults.map{ idSample, target, bam, bai ->
+      [ idSample, target, "${file(outDir).toString()}/bams/${idSample}/${idSample}.bam", "${file(outDir).toString()}/bams/${idSample}/${idSample}.bam.bai" ]
+  }.subscribe { Object obj ->
       file.withWriterAppend { out ->
           out.println "${obj[0]}\t${obj[1]}\t${obj[2]}\t${obj[3]}"
       }


### PR DESCRIPTION
In order to make storeDir work on bam alignment processes, changed outputs of RunBQSR so that only file outputs are emitted. This issue should address but not close #1000. It may take some time to fix the rest of the modules, but this should help alleviate issues by allowing the most storage-heavy processes to use storeDir. 