### PR TITLE
emit original quals

### DIFF
--- a/modules/process/Alignment/RunBQSR.nf
+++ b/modules/process/Alignment/RunBQSR.nf
@@ -52,6 +52,7 @@
       ${knownSites} \
       --verbosity INFO \
       --create-output-bam-index true \
+      --emit-original-quals \
       -O ${idSample}.bam 
    
     echo -e "${idSample}\t\$(du -b ${idSample}.bam)" > file-size.txt
@@ -78,6 +79,7 @@
       --reference ${genomeFile} \
       --create-output-bam-index true \
       --bqsr-recal-file ${idSample}.recal.table \
+      --emit-original-quals \
       --input ${bam} \
       --output ${idSample}.bam
 


### PR DESCRIPTION
Addressing #947

If we want to offset the increase in bam size that will result from this change we can use the following option to change the compression level: `--java-options "-Dsamjdk.compression_level=3"`. i think the default compression level is 2 for gatk, and the higher the compression level the smaller the bam (and the longer other analyses will take). that change is not in the PR yet, but i'm happy to add it.