### PR TITLE
fix failing SV processes in travis CI tests

### DIFF
--- a/modules/process/GermSV/GermlineSVVcf2Bedpe.nf
+++ b/modules/process/GermSV/GermlineSVVcf2Bedpe.nf
@@ -25,14 +25,14 @@ process GermlineSVVcf2Bedpe {
     -o ${outputPrefix}.combined.tmp.bedpe \\
     -t ${outputPrefix}_tmp
 
+  if [ ! -s ${outputPrefix}.combined.tmp.bedpe ] ; then
+    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tNORMAL" >> ${outputPrefix}.combined.tmp.bedpe
+  fi
+
   zgrep "^##" ${vcfFile} | sed "s/##fileformat=*/##fileformat=BEDPE/g" > ${outputPrefix}.combined.unsorted.bedpe
   grep -v "^##" ${outputPrefix}.combined.tmp.bedpe | \\
   awk -F"\\t" -v nid="${idNormal}" -v OFS="\\t" 'NR == 1 {print \$0,"NORMAL_ID";next;}{print \$0,nid}' \\
   >> ${outputPrefix}.combined.unsorted.bedpe
-
-  if [ ! -s ${outputPrefix}.combined.unsorted.bedpe ] ; then 
-    echo -e "#CHROM_A\\tSTART_A\\tEND_A\\tCHROM_B\\tSTART_B\\tEND_B\\tID\\tQUAL\\tSTRAND_A\\tSTRAND_B\\tTYPE\\tFILTER\\tNAME_A\\tREF_A\\tALT_A\\tNAME_B\\tREF_B\\tALT_B\\tINFO_A\\tINFO_B\\tFORMAT\\tNORMAL\\tNORMAL_ID" >> ${outputPrefix}.combined.unsorted.bedpe
-  fi
 
   svtools bedpesort \\
     ${outputPrefix}.combined.unsorted.bedpe \\

--- a/modules/process/SV/SomaticRunSVCircos.nf
+++ b/modules/process/SV/SomaticRunSVCircos.nf
@@ -11,7 +11,7 @@ process SomaticRunSVCircos {
 	output:
 	  path("${outputPrefix}.circos.html")
 
-	when: ["GRCh37","smallGRCh37","GRCh38"].contains(params.genome)
+	when: ["GRCh37","GRCh38"].contains(params.genome)
 
 	script:
 	outputPrefix = "${idTumor}__${idNormal}"


### PR DESCRIPTION
GermlineAnnotateSVBedpe and SomaticRunSVCircos were discovered to be failing during travis tests. Here I fix the header issue with GermlineAnnotateSVBedpe and disabled SomaticRunSVCircos for whenever the smallGRCh37 genome is being used, so they should no longer fail. 