### PR TITLE
Update QcCollectHsMetrics.nf to increase coverage cap

### DIFF
--- a/modules/process/QC/QcCollectHsMetrics.nf
+++ b/modules/process/QC/QcCollectHsMetrics.nf
@@ -34,6 +34,7 @@ process QcCollectHsMetrics {
   """
   gatk CollectHsMetrics \
     ${javaOptions} \
+    --COVERAGE_CAP 1000 \
     --TMP_DIR ./ \
     --INPUT ${bam} \
     --OUTPUT ${idSample}.hs_metrics.txt \


### PR DESCRIPTION
By default CollectHsMetrics cap the coverage to 200.

Temp solution for it is to hard code it as --COVERAGE_CAP 1000.

This will need to be put into ext.args in the nf-core version of the process in the coming updates. And investigations might needed for why a cap is needed at the first place.