### PR TITLE
Bugfix/metadataparser integer overflow

### DIFF
--- a/modules/subworkflow/AggregateFromProcess.nf
+++ b/modules/subworkflow/AggregateFromProcess.nf
@@ -279,7 +279,7 @@ workflow aggregateFromProcess
               .join(inputHsMetrics)
               .set{ inputQcBamAggregate }
 
-    QcBamAggregate(inputQcBamAggregate)
+    QcBamAggregate(inputQcBamAggregate, workflow.projectDir + "/containers/metadataparser/create-aggregate-qc-file.R")
   }
 
   if (conpair4Aggregate) {


### PR DESCRIPTION
In most cases, R's integer data type is implemented as a 32-bit signed integer. This means the range of numbers it can represent is limited:

Minimum value: −2e31 (which is -2,147,483,648)

Maximum value: 2e31−1 (which is 2,147,483,647)

This solution is complicated because the docker image it is using is a very old version R-3.3.2, and the `lib64` package need to be installed as a specific version to the R version.

I'm avoiding to rebuild the docker image, i'm installing the packages in the actual Rscript. We may rebuild the docker image and consolidate a more recent version for R and Python processes in the pipeline when we get to the point to host the image in JFrog.