### PR TITLE
Bugfix/metadataparser integer overflow

### DIFF
--- a/containers/metadataparser/create-aggregate-qc-file.R
+++ b/containers/metadataparser/create-aggregate-qc-file.R
@@ -8,6 +8,13 @@
 ## version = 0.2.1
 ## status  = Dev
 
+install.packages("remotes", repos = "https://cloud.r-project.org", lib = "./")
+library(remotes, lib = "./")
+remotes::install_version("bit", version = "1.1-12", repos = "https://cloud.r-project.org", lib = "./")
+remotes::install_version("bit64", version = "0.9-7", repos = "https://cloud.r-project.org", lib = "./")
+library(bit, lib = "./")
+library(bit64, lib = "./")
+
 suppressPackageStartupMessages({
     library(data.table)
     library(parallel)
@@ -30,7 +37,7 @@ args = parser$parse_args()
 
 ## Parse Alfred output ----------------------------------------------------------------------------------------------
 read_alfred_qc = function(file) {
-    input_file = fread(cmd = paste('zgrep ^ME', file, '| cut -f 2-')) 
+    input_file = fread(cmd = paste('zgrep ^ME', file, '| cut -f 2-'), integer64 = "numeric") 
     ## define column TotalReads
     input_file[, TotalReads := round(`#Mapped`/MappedFraction)]
     ##

--- a/modules/process/Aggregate/QcBamAggregate.nf
+++ b/modules/process/Aggregate/QcBamAggregate.nf
@@ -5,7 +5,8 @@ process QcBamAggregate {
 
   input:
     tuple val(cohort), path(alfredIgnoreYTumor), path(alfredIgnoreYNormal), path(alfredIgnoreNTumor), path(alfredIgnoreNNormal), file(hsMetricsTumor), file(hsMetricsNormal)
-    
+    path(aggregate_qc_Rscript)
+
   output:
     path('alignment_qc.txt'), emit: alignmentQcAggregatedOutput
 
@@ -17,6 +18,6 @@ process QcBamAggregate {
     assayType = 'wgs'
   }
   """
-  Rscript --no-init-file /usr/bin/create-aggregate-qc-file.R -n ${task.cpus} -a ${assayType}
+  Rscript --no-init-file ${aggregate_qc_Rscript} -n ${task.cpus} -a ${assayType}
   """
 }

--- a/modules/subworkflow/AggregateFromProcess.nf
+++ b/modules/subworkflow/AggregateFromProcess.nf
@@ -279,7 +279,7 @@ workflow aggregateFromProcess
               .join(inputHsMetrics)
               .set{ inputQcBamAggregate }
 
-    QcBamAggregate(inputQcBamAggregate)
+    QcBamAggregate(inputQcBamAggregate, workflow.projectDir + "/containers/metadataparser/create-aggregate-qc-file.R")
   }
 
   if (conpair4Aggregate) {

--- a/modules/subworkflow/AggregateFromResult.nf
+++ b/modules/subworkflow/AggregateFromResult.nf
@@ -136,7 +136,7 @@ workflow aggregateFromResult
     inputAlfredIgnoreY.join(inputAlfredIgnoreN)
               .join(inputHsMetrics)
               .set{ inputQcBamAggregate }
-    QcBamAggregate(inputQcBamAggregate)
+    QcBamAggregate(inputQcBamAggregate, workflow.projectDir + "/containers/metadataparser/create-aggregate-qc-file.R")
 
     inputConpairConcord4Aggregate.join(inputConpairContami4Aggregate)
         .set{ inputQcConpairAggregate }


### PR DESCRIPTION
In most cases, R's integer data type is implemented as a 32-bit signed integer. This means the range of numbers it can represent is limited:

Minimum value: −2e31 (which is -2,147,483,648)

Maximum value: 2e31−1 (which is 2,147,483,647)

This solution is complicated because the docker image it is using is a very old version R-3.3.2, and the `lib64` package need to be installed as a specific version to the R version.

I'm avoiding to rebuild the docker image, i'm installing the packages in the actual Rscript. We may rebuild the docker image and consolidate a more recent version for R and Python processes in the pipeline when we get to the point to host the image in JFrog.

---
**Note:** This PR replaces #1039 which was automatically closed due to repository history cleanup.