### PR TITLE
Feature/create pon

### DIFF
--- a/conf/containers.config
+++ b/conf/containers.config
@@ -109,6 +109,9 @@
   withName:GermlineMergeDellyAndManta {
     container = "cmopipeline/bcftools-vt:1.1.1"
   }
+  withName:FilterGermlineStrelka2 {
+    container = "cmopipeline/bcftools-vt:1.1.1"
+  }
   withName:generatePoN {
     container = "cmopipeline/bcftools-vt:1.1.1"
   }

--- a/conf/containers.config
+++ b/conf/containers.config
@@ -49,7 +49,7 @@
     container = "cmopipeline/bcftools-vt:1.2.2"
   }
   withName:SomaticAnnotateMaf {
-    container = "cmopipeline/vcf2maf:vep88_1.2.3"
+    container = "cmopipeline/vcf2maf:vep88_1.2.5"
   }
   withName:DoFacets {
     container = "cmopipeline/facets-suite-preview-htstools:0.0.1"
@@ -101,7 +101,7 @@
     container = "cmopipeline/bcftools-vt:1.2.2"
   }
   withName:GermlineAnnotateMaf {
-    container = "cmopipeline/vcf2maf:vep88_1.2.3"
+    container = "cmopipeline/vcf2maf:vep88_1.2.5"
   }
   withName:GermlineFacetsAnnotation {
     container = "cmopipeline/facets-suite-preview-htstools:0.0.1"

--- a/conf/containers.config
+++ b/conf/containers.config
@@ -30,10 +30,10 @@
   withName:SomaticDellyCall {
     container = "cmopipeline/delly-bcftools:0.0.1"
   }
-  withName:RunMutect2 {
+  withName:".*RunMutect2" {
     container = "broadinstitute/gatk:4.1.0.0"
   }
-  withName:SomaticCombineMutect2Vcf {
+  withName:".*CombineMutect2Vcf" {
     container = "cmopipeline/bcftools-vt:1.2.0"
   }
   withName:SomaticRunManta {
@@ -107,6 +107,9 @@
     container = "cmopipeline/facets-suite-preview-htstools:0.0.1"
   } 
   withName:GermlineMergeDellyAndManta {
+    container = "cmopipeline/bcftools-vt:1.1.1"
+  }
+  withName:generatePoN {
     container = "cmopipeline/bcftools-vt:1.1.1"
   }
 

--- a/containers/vcf2maf/filter-germline-pon-maf.R
+++ b/containers/vcf2maf/filter-germline-pon-maf.R
@@ -1,0 +1,97 @@
+#!/usr/bin/env Rscript
+
+# __author__  = "Philip Jonsson"
+# __email__   = "jonssonp@mskcc.org"
+# __version__ = "0.2.0"
+# __status__  = "Dev"
+
+suppressPackageStartupMessages({
+    library(data.table)
+    library(annotateMaf)
+    library(argparse)
+})
+
+Sys.setenv("VROOM_CONNECTION_SIZE" = 131072 * 3)
+args = commandArgs(TRUE)
+
+if (is.null(args) | length(args)<1) {
+    message('Run filter-germline-maf.R --help for list of input arguments.')
+    quit()
+}
+
+parser = ArgumentParser(description = 'Flag and filter somatic variants in input MAF file, output is a filtered and unfiltered but filter-tagged MAF file.')
+parser$add_argument('-m', '--maf-file', type = 'character', required = TRUE,
+                    help = 'VEP-annotated MAF file')
+parser$add_argument('-o', '--output-prefix', type = 'character', required = TRUE,
+                    help = 'Prefix of output files')
+parser$add_argument('-nd', '--normal-depth', type = 'integer', required = FALSE,
+                    default = 20, help = 'Normal variant loci total depth cut-off [default %(default)s]')
+parser$add_argument('-nv', '--normal-vaf', type = 'double', required = FALSE,
+                    default = 0.35, help = 'Normal variant allele frequency cut-off [default %(default)s]')   
+parser$add_argument('-sv', '--somatic-vaf', type = 'double', required = FALSE,
+                    default = 0.05, help = 'Somatic variant allele frequency cut-off [default %(default)s]') 
+
+# Get inputs
+args = parser$parse_args()
+maf = args$maf_file
+output_prefix = args$output_prefix
+normal_depth_cutoff = args$normal_depth
+normal_vaf_cutoff = args$normal_vaf
+somatic_vaf_cutoff = args$somatic_vaf
+
+add_tag = function(filter, tag) {
+    ifelse(filter == 'PASS',
+           tag,
+           paste(filter, tag, sep = ';'))
+}
+
+format_tag = function(pretag){
+    gsub("-","_",gsub(" ", "_", tolower(pretag)))
+}
+
+ch_genes = c("ASXL1", "ATM", "BCOR", "CALR", "CBL", "CEBPA", "CREBBP", "DNMT3A", "ETV6", "EZH2", "FLT3", "GNAS",
+             "IDH1", "IDH2", "JAK2", "KIT", "KRAS", "MPL", "MYD88", "NF1", "NPM1", "NRAS", "PPM1D", "RAD21", "RUNX1", "SETD2", "SF3B1", "SH2B3", "SRSF2", "STAG2", "STAT3", "TET2", "TP53", "U2AF1", "WT1", "ZRSR2")
+
+maf = fread(maf, data.table = TRUE)
+
+# Tag input MAF with filters --------------------------------------------------------------------------------------
+#maf[, `:=` (t_var_freq = t_alt_count/(t_alt_count+t_ref_count),
+maf[, `:=`  (n_var_freq = n_alt_count/(n_alt_count+n_ref_count),
+            EncodeDacMapability = ifelse(is.na(EncodeDacMapability), '', EncodeDacMapability),
+            RepeatMasker = ifelse(is.na(RepeatMasker), '', RepeatMasker),
+            gnomAD_FILTER = ifelse(is.na(gnomAD_FILTER), 0, 1),
+            ch_gene = Hugo_Symbol %in% ch_genes,
+            mutation_effect = ifelse(is.na(mutation_effect), '', mutation_effect),
+            oncogenic = ifelse(is.na(oncogenic), '', oncogenic)
+)]
+
+maf[n_depth < normal_depth_cutoff, FILTER := add_tag(FILTER, 'low_n_depth')]
+maf[n_var_freq < somatic_vaf_cutoff, FILTER := add_tag(FILTER, 'low_vaf')]
+#maf[!ch_gene & n_var_freq < normal_vaf_cutoff & !Variant_Classification %in% c('INS', 'DEL'), FILTER := add_tag(FILTER, 'low_n_vaf')]
+#maf[!ch_gene & n_var_freq < (normal_vaf_cutoff - 0.10) & Variant_Classification %in% c('INS', 'DEL'), FILTER := add_tag(FILTER, 'low_n_vaf')]
+#maf[ch_gene & n_var_freq < normal_vaf_cutoff & t_var_freq < .25, FILTER := add_tag(FILTER, 'ch_mutation')]
+maf[ch_gene & n_var_freq < normal_vaf_cutoff, FILTER := add_tag(FILTER, 'ch_mutation')]
+#maf[t_var_freq > 3 * n_var_freq, FILTER := add_tag(FILTER, 't_in_n_contamination')]
+maf[EncodeDacMapability != '', FILTER := add_tag(FILTER, 'mappability')]
+maf[RepeatMasker != '', FILTER := add_tag(FILTER, 'repeatmasker')]
+maf[gnomAD_FILTER == 1, FILTER := add_tag(FILTER, 'gnomad_filter')]
+maf[mutation_effect != '', FILTER := add_tag(FILTER,format_tag(mutation_effect))]
+maf[oncogenic != '', FILTER := add_tag(FILTER,format_tag(oncogenic))]
+
+
+# Add BRCA annotation ---------------------------------------------------------------------------------------------
+maf = brca_annotate_maf(maf)
+maf = hotspot_annotate_maf(maf)
+
+# Write filtered and tagged input MAF -----------------------------------------------------------------------------
+maf = as.data.table(maf) # necessary because of the class of output from previous call
+#maf[Hotspot == TRUE & t_var_freq >= 0.02 & FILTER == 'low_vaf', FILTER := 'PASS'] # note: variants flagged by other filters will not be rescued by this
+#maf[Hotspot == TRUE & FILTER == 'low_mapping_quality', FILTER := 'PASS']
+#maf[Hotspot == TRUE & FILTER == 'low_t_depth', FILTER := 'PASS']
+#maf[Hotspot == TRUE & FILTER == 'strand_bias', FILTER := 'PASS']
+maf[Hotspot == TRUE, FILTER := add_tag(FILTER, 'hotspot')]
+
+filter_maf = maf[FILTER == 'PASS']
+
+fwrite(maf, paste0(output_prefix, '.unfiltered.maf'), sep = '\t')
+fwrite(filter_maf, paste0(output_prefix, '.maf'), sep = '\t')

--- a/pon.nf
+++ b/pon.nf
@@ -1,0 +1,384 @@
+referenceMap = defineReferenceMap()
+outDir     = file(params.outDir).toAbsolutePath()
+mappingFile = file(params.bamMapping, checkIfExists: true)
+
+TempoUtils.extractBAM(mappingFile, params.assayType)
+	.into{bams4MutectGermline; bams4MantaGermline; bamsForStrelkaGermline}
+
+process GermlineRunManta {
+	tag {idNormal}
+
+	input:
+	set idNormal, target, file(bamNormal), file(baiNormal) from bams4MantaGermline
+	set file(genomeFile), file(genomeIndex) from Channel.value([
+      referenceMap.genomeFile, referenceMap.genomeIndex
+    ])
+    set file(svCallingIncludeRegions), file(svCallingIncludeRegionsIndex) from Channel.value([
+      referenceMap.svCallingIncludeRegions, referenceMap.svCallingIncludeRegionsIndex
+    ])
+
+	output:
+	set idNormal, target, file("*.candidateSmallIndels.vcf.gz"), file("*.candidateSmallIndels.vcf.gz.tbi") into mantaOutput
+	
+	script:
+	outputPrefix = "${idNormal}"
+	options = ""
+	if (params.assayType == "exome") options = "--exome"
+	"""
+	configManta.py \\
+	  ${options} \\
+	  --callRegions ${svCallingIncludeRegions} \\
+	  --reference ${genomeFile} \\
+	  --bam ${bamNormal} \\
+	  --runDir Manta
+	python Manta/runWorkflow.py \\
+	  --mode local \\
+	  --jobs ${task.cpus}
+
+	mv Manta/results/variants/candidateSmallIndels.vcf.gz \\
+	  Manta_${outputPrefix}.candidateSmallIndels.vcf.gz
+	mv Manta/results/variants/candidateSmallIndels.vcf.gz.tbi \\
+	  Manta_${outputPrefix}.candidateSmallIndels.vcf.gz.tbi
+	"""
+}
+
+bamsForStrelkaGermline.join(mantaOutput, by:[0,1])
+	.set{bamsForStrelkaGermline}
+
+process GermlineRunStrelka2 {
+	tag {idNormal}
+
+	publishDir "${outDir}/pon/${idNormal}/strelka2", mode: params.publishDirMode
+
+	input:
+	set idNormal, target, file(bamNormal), file(baiNormal), file(mantaCSI), file(mantaCSI_idx) from bamsForStrelkaGermline
+	set file(genomeFile), file(genomeIndex), file(genomeDict) from Channel.value([
+      referenceMap.genomeFile, referenceMap.genomeIndex, referenceMap.genomeDict
+    ])
+    set file(idtTargets), file(idtTargetsIndex) from Channel.value([referenceMap.idtTargets, referenceMap.idtTargetsIndex])
+    set file(idtv2Targets), file(idtv2TargetsIndex) from Channel.value([referenceMap.idtv2Targets, referenceMap.idtv2TargetsIndex])
+    set file(agilentTargets), file(agilentTargetsIndex) from Channel.value([referenceMap.agilentTargets, referenceMap.agilentTargetsIndex])
+    set file(wgsIntervals), file(wgsIntervalssIndex) from Channel.value([referenceMap.wgsTargets, referenceMap.wgsTargetsIndex])
+
+	output:
+	set idNormal, target, file("${idNormal}.strelka2.vcf.gz"), file("${idNormal}.strelka2.vcf.gz.tbi") into StrelkaGermline_out
+	set file("listoffiles.txt"), file("listoffiles2.txt") into outFiles
+
+	script:
+	options = ""
+	intervals = wgsIntervals
+	if (params.assayType == "exome") {
+		options = "--exome"
+		if (target == 'agilent') intervals = agilentTargets
+		if (target == 'idt') intervals = idtTargets
+		if (target == 'idt_v2') intervals = idtTargets
+	}
+"""
+configureStrelkaGermlineWorkflow.py \\
+    ${options} \\
+    --callRegions ${intervals} \\
+    --referenceFasta ${genomeFile} \\
+    --bam ${bamNormal} \\
+    --indelCandidates ${mantaCSI} \\
+    --runDir Strelka
+
+python Strelka/runWorkflow.py \\
+    --mode local \\
+    --jobs ${task.cpus}
+
+find . -type f > listoffiles.txt
+
+bcftools filter \\
+    --include 'FORMAT/AD[0:1]>1' \\
+    Strelka/results/variants/variants.vcf.gz | \\
+    bcftools norm \\
+    --fasta-ref ${genomeFile} \\
+    -check-ref s \\
+    --multiallelics -both \\
+    --output-type z \\
+    --output ${idNormal}.strelka2.vcf.gz
+
+tabix --preset vcf ${idNormal}.strelka2.vcf.gz
+
+find . -type f > listoffiles2.txt
+"""
+}
+
+process CreateScatteredIntervals {
+ 	input:
+    set file(genomeFile), file(genomeIndex), file(genomeDict) from Channel.value([
+      referenceMap.genomeFile, referenceMap.genomeIndex, referenceMap.genomeDict
+      ])
+    set file(idtTargets), file(idtv2Targets), file(agilentTargets), file(wgsTargets),
+    file(idtTargetsIndex), file(idtv2TargetsIndex), file(agilentTargetsIndex), file(wgsTargetsIndex) from Channel.value([
+      referenceMap.idtTargets, referenceMap.idtv2Targets, referenceMap.agilentTargets, referenceMap.wgsTargets,
+      referenceMap.idtTargetsIndex, referenceMap.idtv2TargetsIndex, referenceMap.agilentTargetsIndex, referenceMap.wgsTargetsIndex
+      ])
+  
+	output:
+    set file("agilent*.interval_list"), val("agilent"), val("agilent") into agilentIList
+    set file("idt*.interval_list"), val("idt"), val("idt") into idtIList
+    set file("wgs*.interval_list"), val("wgs"), val("wgs") into wgsIList
+    set file("idt*.interval_list"), val("idt_v2"), val("idt_v2") into idtv2IList
+
+	script:
+	scatterCount = params.scatterCount
+	"""
+	gatk SplitIntervals \\
+	  --reference ${genomeFile} \\
+	  --intervals ${agilentTargets} \\
+	  --scatter-count ${scatterCount} \\
+	  --subdivision-mode BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW \\
+	  --output agilent
+	for i in agilent/*.interval_list;
+	do
+		BASENAME=`basename \$i`
+		mv \$i agilent-\$BASENAME
+	done
+	gatk SplitIntervals \\
+	  --reference ${genomeFile} \\
+	  --intervals ${idtTargets} \\
+	  --scatter-count ${scatterCount} \\
+	  --subdivision-mode BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW \\
+	  --output idt
+	for i in idt/*.interval_list;
+	do
+		BASENAME=`basename \$i`
+		mv \$i idt-\$BASENAME
+	done
+	gatk SplitIntervals \\
+	  --reference ${genomeFile} \\
+	  --intervals ${idtv2Targets} \\
+	  --scatter-count ${scatterCount} \\
+	  --subdivision-mode BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW \
+	  --output idt_v2
+	for i in idt_v2/*.interval_list;
+	do
+		BASENAME=`basename \$i`
+		mv \$i idt_v2-\$BASENAME
+	done
+	gatk SplitIntervals \\
+	  --reference ${genomeFile} \\
+	  --intervals ${wgsTargets} \\
+	  --scatter-count ${scatterCount} \\
+	  --subdivision-mode INTERVAL_SUBDIVISION \\
+	  --output wgs 
+	for i in wgs/*.interval_list;
+	do
+		BASENAME=`basename \$i`
+		mv \$i wgs-\$BASENAME
+	done
+  """
+}
+
+agilentIList.mix(idtIList, wgsIList, idtv2IList).set{mergedIList4N}
+
+bams4MutectGermline.combine(mergedIList4N, by:1)
+.map{ item ->
+    def idNormal = item[1]
+    def target = item[0]
+    def normalBam = item[2]
+    def normalBai = item[3]
+    def intervalBed = item[4]
+    def key = "${idNormal}@${target}" // adding one unique key
+
+    return [ key, idNormal, target, normalBam, normalBai, intervalBed ]
+}.map{ 
+    key, idNormal, target, normalBam, normalBai, intervalBed -> 
+    tuple ( 
+         groupKey(key, intervalBed.size()), // adding numbers so that each sample only wait for it's own children processes
+         idNormal, target, normalBam, normalBai, intervalBed
+    )
+}
+.transpose()
+.set{ mergedChannelGermline }
+
+process GermlineRunMutect2 {
+	tag {idNormal}
+
+	input:
+	set key, idNormal, target, file(bamNormal), file(baiNormal), file(intervalBed) from mergedChannelGermline 
+	set file(genomeFile), file(genomeIndex), file(genomeDict) from Channel.value([
+      referenceMap.genomeFile, referenceMap.genomeIndex, referenceMap.genomeDict
+    ])
+
+	output:
+    set id, idNormal, target, file("*filtered.vcf.gz"), file("*filtered.vcf.gz.tbi"), file("*Mutect2FilteringStats.tsv") into forGermlineMutect2Combine
+
+	script:
+	mutect2Vcf = "${idNormal}_${intervalBed.baseName}.vcf.gz"
+  	prefix = "${mutect2Vcf}".replaceFirst(".vcf.gz", "")
+	"""
+	gatk --java-options -Xmx8g Mutect2 \\
+    --reference ${genomeFile} \\
+    --intervals ${intervalBed} \\
+    --input ${bamNormal} \\
+     --tumor ${idNormal} \\
+     --output ${mutect2Vcf}
+
+    gatk --java-options -Xmx8g FilterMutectCalls \\
+    --variant ${mutect2Vcf} \\
+    --stats ${prefix}.Mutect2FilteringStats.tsv \\
+    --output ${prefix}.gatk-filtered.vcf.gz
+	
+	find . -type f > listoffiles.txt
+	"""
+}
+
+forGermlineMutect2Combine.groupTuple(by:[0,1,2]).set{ forGermlineMutect2Combine }
+
+process GermlineCombineMutect2Vcf {
+  tag {idNormal}
+
+  publishDir "${outDir}/pon/${idNormal}/mutect2", mode: params.publishDirMode
+
+  input:
+    set id, idNormal, target, file(mutect2Vcf), file(mutect2VcfIndex), file(mutect2Stats) from forGermlineMutect2Combine
+    set file(genomeFile), file(genomeIndex), file(genomeDict) from Channel.value([
+      referenceMap.genomeFile, referenceMap.genomeIndex, referenceMap.genomeDict
+    ])
+
+  output:
+    set idNormal, target, file("${outfile}"), file("${outfile}.tbi") into mutect2CombinedVcf4Combine
+
+  when: "mutect2" in tools 
+
+  script:
+  //def idNormal = id.toString().split("@")[0].split("__")[1]
+  //def target   = id.toString().split("@")[1]
+  def outfile  = "${idNormal}.mutect2.vcf.gz"
+  """
+  bcftools concat \\
+    --allow-overlaps \\
+    ${mutect2Vcf} | \\
+  bcftools sort | \\
+  bcftools norm \\
+    --fasta-ref ${genomeFile} \\
+    --check-ref s \\
+    --multiallelics -both | \\
+  bcftools norm --rm-dup all | \\
+  bcftools view \\
+    --samples ${idNormal} \\
+    --output-type z | \\
+  bcftools filter \\
+    --include 'FORMAT/AD[0:1]>1' | \\
+    sed -e 's/ID=RU,Number=1/ID=RU,Number=A/' -e 's/ID=AD,Number=R/ID=AD,Number=./' | \\
+  bcftools norm \\
+    --fasta-ref ${genomeFile} \\
+    --check-ref s \\
+    --multiallelics -both \\
+    --output-type z \\
+    --output ${outfile}
+
+  tabix --preset vcf ${outfile}
+  """
+}
+
+mutect2CombinedVcf4Combine.groupTuple(by:[1])
+	.combine(StrelkaGermline_out.groupTuple(by:[1]), by:[1])
+	.set{ponInputs}
+
+process generatePoN {
+	tag {target}
+
+	publishDir "${outDir}/pon/${idNormal}/pon/${target}", mode: params.publishDirMode
+	
+	input:
+	set idNormals, target, file(mutectCalls), file(mutectCallsTbi), file(strelkaCalls), file(strelkaCallsTbi) from ponInputs
+
+	output:
+	file("pon.annot.vcf.gz") into ponOutput
+
+	script:
+	"""
+	bcftools merge \
+		--merge none \
+		--output-type z \
+		--output pon.vcf.gz \
+		pon/*vcf.gz
+
+	bcftools +fill-tags pon.vcf.gz \\
+		--output-type z \\
+		--output pon.annot.vcf.gz \\
+		--tags AC
+
+	tabix --preset vcf pon.annot.vcf.gz
+	"""
+
+}
+
+def checkParamReturnFile(item) {
+  params."${item}" = params.genomes[params.genome]."${item}"
+  if(params."${item}" == null){println "${item} is not found in reference map"; exit 1}
+  if(file(params."${item}", checkIfExists: false) == []){println "${item} is not found; glob pattern produces empty list"; exit 1}
+  return file(params."${item}", checkIfExists: true)
+}
+
+def defineReferenceMap() {
+  if (!(params.genome in params.genomes)) exit 1, "Genome ${params.genome} not found in configuration"
+  result_array = [
+    // genome reference dictionary
+    'genomeDict' : checkParamReturnFile("genomeDict"),
+    // FASTA genome reference
+    'genomeFile' : checkParamReturnFile("genomeFile"),
+    // genome .fai file
+    'genomeIndex' : checkParamReturnFile("genomeIndex"),
+    // VCFs with known indels (such as 1000 Genomes, Mill’s gold standard)
+    'svCallingExcludeRegions' : checkParamReturnFile("svCallingExcludeRegions"),
+    'svCallingIncludeRegions' : checkParamReturnFile("svCallingIncludeRegions"),
+    'svCallingIncludeRegionsIndex' : checkParamReturnFile("svCallingIncludeRegionsIndex"),
+    // Target and Bait BED files
+    'idtTargets' : checkParamReturnFile("idtTargets"),
+    //'idtTargetsUnzipped' : checkParamReturnFile("idtTargetsUnzipped"),
+    'idtTargetsIndex' : checkParamReturnFile("idtTargetsIndex"),
+    'idtTargetsList' : checkParamReturnFile("idtTargetsList"),  
+    'idtBaitsList' : checkParamReturnFile("idtBaitsList"), 
+    'idtv2Targets' : checkParamReturnFile("idtv2Targets"),
+    'idtv2TargetsIndex' : checkParamReturnFile("idtv2TargetsIndex"),
+    'idtv2TargetsList' : checkParamReturnFile("idtv2TargetsList"),  
+    'idtv2BaitsList' : checkParamReturnFile("idtv2BaitsList"), 
+    'agilentTargets' : checkParamReturnFile("agilentTargets"),
+    //'agilentTargetsUnzipped' : checkParamReturnFile("agilentTargetsUnzipped"),
+    'agilentTargetsIndex' : checkParamReturnFile("agilentTargetsIndex"),
+    'agilentTargetsList' : checkParamReturnFile("agilentTargetsList"),  
+    'agilentBaitsList' : checkParamReturnFile("agilentBaitsList"), 
+    'wgsTargets' : checkParamReturnFile("wgsTargets"),
+    //'wgsTargetsUnzipped' : checkParamReturnFile("wgsTargetsUnzipped"),
+    'wgsTargetsIndex' : checkParamReturnFile("wgsTargetsIndex")
+  ]
+
+  if (workflow.profile != "test") {
+    result_array << ['vepCache' : checkParamReturnFile("vepCache")]
+    // intervals file for spread-and-gather processes
+    result_array << ['intervals' : checkParamReturnFile("intervals")]
+    // files for CombineChannel, needed by bcftools annotate
+    result_array << ['repeatMasker' : checkParamReturnFile("repeatMasker")]
+    result_array << ['repeatMaskerIndex' : checkParamReturnFile("repeatMaskerIndex")]
+    result_array << ['mapabilityBlacklist' : checkParamReturnFile("mapabilityBlacklist")]
+    result_array << ['mapabilityBlacklistIndex' : checkParamReturnFile("mapabilityBlacklistIndex")]
+    // isoforms needed by vcf2maf
+    result_array << ['isoforms' : checkParamReturnFile("isoforms")]
+    // PON files
+    result_array << ['exomePoN' : checkParamReturnFile("exomePoN")]
+    result_array << ['exomePoNIndex' : checkParamReturnFile("exomePoNIndex")]
+    result_array << ['wgsPoN' : checkParamReturnFile("wgsPoN")]
+    result_array << ['wgsPoNIndex' : checkParamReturnFile("wgsPoNIndex")]
+    // gnomAD resources
+    result_array << ['gnomadWesVcf' : checkParamReturnFile("gnomadWesVcf")]
+    result_array << ['gnomadWesVcfIndex' : checkParamReturnFile("gnomadWesVcfIndex")]
+    result_array << ['gnomadWgsVcf' : checkParamReturnFile("gnomadWgsVcf")]
+    result_array << ['gnomadWgsVcfIndex' : checkParamReturnFile("gnomadWgsVcfIndex")]
+    // HLA FASTA and *dat for LOHHLA 
+    result_array << ['hlaFasta' : checkParamReturnFile("hlaFasta")] 
+    result_array << ['hlaDat' : checkParamReturnFile("hlaDat")] 
+    // files for neoantigen & NetMHC
+    result_array << ['neoantigenCDNA' : checkParamReturnFile("neoantigenCDNA")]
+    result_array << ['neoantigenCDS' : checkParamReturnFile("neoantigenCDS")]
+    // coding region BED files for calculating TMB
+    result_array << ['idtCodingBed' : checkParamReturnFile("idtCodingBed")]
+    result_array << ['idtv2CodingBed' : checkParamReturnFile("idtv2CodingBed")]
+    result_array << ['agilentCodingBed' : checkParamReturnFile("agilentCodingBed")]    
+    result_array << ['wgsCodingBed' : checkParamReturnFile("wgsCodingBed")]  
+  }
+  return result_array
+}


### PR DESCRIPTION
*****************
*      Draft PR      *
*****************


Addressing #126. New workflow mirroring steps in the main pipeline to generate PoN as per the instructions here: https://ccstempo.netlify.app/wes-panel-of-normals.html#strelka2. It capitalizes on the resources, configurations and libraries already existing for similar steps in the main pipeline. It is not meant to be run very often or in step with the main workflow, which is why we are not replicating extra functions like the watch mode.

Currently it takes in the --bamMapping file, in the same format that the main workflow takes. However we may want to consider adding another column to indicate sequencer type (Novaseq vs Hiseq, for example). 

Remaining steps include annotation of normal calls. This is necessary to look at certain features, such as clonal hematopoiesis mutations, to decide if the germline sample should be included in the final PoN. 

Also, variants that are not present in a minimum number of samples should be filtered out (gatk best practices suggests variants present in less than 2 samples should be filtered out). This can be achieved using `bcftools isec`

---
**Note:** This PR replaces #893 which was automatically closed due to repository history cleanup.