### PR TITLE
Fix CI: Remove oncokb_genes file dependency and use process substitution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NXF_VER: "25.04.7"
 

--- a/modules/process/SNV/SomaticAnnotateMaf.nf
+++ b/modules/process/SNV/SomaticAnnotateMaf.nf
@@ -6,7 +6,6 @@ process SomaticAnnotateMaf {
   input:
     tuple val(idTumor), val(idNormal), val(target), path(vcfMerged)
     tuple path(genomeFile), path(genomeIndex), path(genomeDict), path(vepCache), path(isoforms)
-    path(oncokb_genes) // used for test, test_singularity profile only
 
   output:
     tuple val(idTumor), val(idNormal), val(target), path("${outputPrefix}.maf"), emit: mafFile
@@ -66,6 +65,6 @@ process SomaticAnnotateMaf {
     --normal-panel-count ${params.somaticVariant.ponCount} \
     --maf-file ${outputPrefix}.raw.oncokb.maf \
     --output-prefix ${outputPrefix} \
-    --onco "${["test","test_singularity"].contains(workflow.profile) ? oncokb_genes : "https://data-legacy.oncokb.aws.mskcc.org/api/v1/genes/" }"
+    --onco ${["test","test_singularity"].contains(workflow.profile) ? "<(echo '[]')" : "'https://data-legacy.oncokb.aws.mskcc.org/api/v1/genes/'" }
   """
 }

--- a/modules/process/SNV/SomaticAnnotateMaf.nf
+++ b/modules/process/SNV/SomaticAnnotateMaf.nf
@@ -65,6 +65,6 @@ process SomaticAnnotateMaf {
     --normal-panel-count ${params.somaticVariant.ponCount} \
     --maf-file ${outputPrefix}.raw.oncokb.maf \
     --output-prefix ${outputPrefix} \
-    --onco ${["test","test_singularity"].contains(workflow.profile) ? "<(echo '[]')" : "'https://data-legacy.oncokb.aws.mskcc.org/api/v1/genes/'" }
+    --onco ${["test","test_singularity"].contains(workflow.profile) ? "\$(echo '[]' > empty.json && echo empty.json)" : "'https://data-legacy.oncokb.aws.mskcc.org/api/v1/genes/'" }
   """
 }

--- a/modules/subworkflow/snv_wf.nf
+++ b/modules/subworkflow/snv_wf.nf
@@ -69,11 +69,7 @@ workflow snv_wf
 
     SomaticAnnotateMaf(SomaticCombineChannel.out.mutationMergedVcf,
                         Channel.value([referenceMap.genomeFile, referenceMap.genomeIndex, referenceMap.genomeDict,
-                                        referenceMap.vepCache, referenceMap.isoforms]),
-                        ["test","test_singularity"].contains(workflow.profile) ?
-                            Channel.value([file(workflow.projectDir + "/containers/vcf2maf/oncokb_genes.json")]) :
-                            Channel.value([])
-                                        )
+                                        referenceMap.vepCache, referenceMap.isoforms]))
 
 
     hlaOutput.combine(SomaticAnnotateMaf.out.mafFile, by: [1,2]).set{ input4Neoantigen }


### PR DESCRIPTION
### CI Fixes

Cleanup work for #1042 and #1043

- Remove oncokb_genes file dependency by using empty files
- Resolved the 'Process Substitution' error in \`SomaticAnnotateMaf.nf\` by ensuring POSIX compliance (using empty files instead of \`<(echo ...)\`).
- Update CI workflow to use Ubuntu 24.04 to avoid `no space left on device issue`